### PR TITLE
fix buffer overread in get_feature_data

### DIFF
--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -487,7 +487,7 @@ vector<uint8_t> get_feature_data(uint8_t reportId, uint16_t len) {
     if (!feature_data.contains(reportId) || reportId == 0x81) {
         if (hid_control_cid != 0) {
             uint8_t get_feature[] = {0x43, reportId};
-            l2cap_send(hid_control_cid, get_feature, len);
+            l2cap_send(hid_control_cid, get_feature, sizeof(get_feature));
             printf("[L2CAP] Requesting Get Feature Report 0x%02X\n", reportId);
         }
     }


### PR DESCRIPTION
## Summary

`get_feature_data()` passes the caller's `len` parameter to `l2cap_send`, but the `get_feature` array is only 2 bytes. This reads up to 62 bytes of uninitialized stack memory and sends it over Bluetooth.

Fix: use `sizeof(get_feature)` which correctly sends only the 2-byte GET_REPORT request header (`0x43` + report ID).

## Details

The BT HID GET_REPORT transaction only requires the transaction type byte and report ID. The `len` parameter represents the expected *response* size, not the *request* size.

Called from `init_feature()` with lengths 20, 41, and 64 — all far exceeding the 2-byte array.

## Test plan

- [ ] Verify feature reports (0x05, 0x09, 0x20, 0x22) are still retrieved successfully on connection
- [ ] Confirm controller pairing and normal operation unchanged