### PR TITLE
feat(pm): disconnect controller on USB suspend

### DIFF
--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -13,6 +13,7 @@
 #include "pico/cyw43_arch.h"
 #include "utils.h"
 #include "bsp/board_api.h"
+#include "tusb.h"
 #include "classic/sdp_server.h"
 #include "config.h"
 #include "pico/util/queue.h"
@@ -305,7 +306,11 @@ static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
             feature_data.clear();
             cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
             printf("[HCI] Disconnected reason=0x%02X, start inquiry\n", reason);
-            gap_inquiry_start(30);
+            if (!tud_suspended()) {
+                gap_inquiry_start(30);
+            } else {
+                printf("[HCI] USB suspended, skip inquiry\n");
+            }
             break;
         }
     }

--- a/src/bt.h
+++ b/src/bt.h
@@ -19,6 +19,7 @@ int bt_init();
 void bt_register_data_callback(bt_data_callback_t callback);
 void bt_send_packet(uint8_t *data, uint16_t len);
 void bt_send_control(uint8_t *data, uint16_t len);
+bool bt_disconnect();
 void bt_write(uint8_t* data,uint16_t len);
 std::vector<uint8_t> get_feature_data(uint8_t reportId,uint16_t len);
 void init_feature();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include "pico/cyw43_arch.h"
 #include "config.h"
 #include "cmd.h"
+#include "usb.h"
 
 // Pico SDK speciifically for waiting on conditions
 #include "pico/critical_section.h"
@@ -215,6 +216,7 @@ int main() {
         watchdog_update();
         cyw43_arch_poll();
         tud_task();
+        usb_pm_poll();
         audio_loop();
         interrupt_loop();
     }

--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -5,8 +5,14 @@
 #include "tusb.h"
 #include "bsp/board_api.h"
 
+#include "bt.h"
+#include "usb.h"
+
 uint8_t mute[2]; // 0: SPEAKER(0x02) 1: MIC(0x05)
 float volume[2] = {1.0f}; // 0: SPEAKER(0x02) 1: MIC(0x05)
+
+static volatile bool s_usb_suspended = false;
+static volatile bool s_disconnect_requested = false;
 
 #define UAC1_ENTITY_SPK_FEATURE_UNIT    0x02
 #define UAC1_ENTITY_MIC_FEATURE_UNIT    0x05
@@ -161,4 +167,28 @@ bool tud_audio_set_req_entity_cb(uint8_t rhport, tusb_control_request_t const *p
 void tud_hid_report_complete_cb(uint8_t instance, uint8_t const *report, uint16_t len) {
     (void) instance;
     (void) len;
+}
+
+extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
+    (void) remote_wakeup_en;
+
+    // TinyUSB callbacks can run in IRQ context. Defer BTstack calls to main loop.
+    s_usb_suspended = true;
+    s_disconnect_requested = true;
+}
+
+extern "C" void tud_resume_cb(void) {
+    s_usb_suspended = false;
+}
+
+void usb_pm_poll() {
+    if (!s_disconnect_requested) {
+        return;
+    }
+    s_disconnect_requested = false;
+
+    // Let the controller go idle when the host suspends.
+    if (s_usb_suspended) {
+        bt_disconnect();
+    }
 }

--- a/src/usb.h
+++ b/src/usb.h
@@ -8,4 +8,7 @@
 extern uint8_t mute[2]; // 0: SPEAKER(0x02) 1: MIC(0x05)
 extern float volume[2]; // 0: SPEAKER(0x02) 1: MIC(0x05)
 
+// Defer USB suspend actions to main loop.
+void usb_pm_poll();
+
 #endif //DS5_BRIDGE_USB_H


### PR DESCRIPTION
## Summary
Disconnect the DualSense Bluetooth link when the USB host suspends, so the controller can enter its normal sleep state and stop staying “awake” while the PC is sleeping.
## Details
- Handles USB suspend via TinyUSB `tud_suspend_cb()`.
- Defers the actual `bt_disconnect()` call to the main loop to avoid calling BTstack from USB callback context.
- Skips restarting BT inquiry on disconnect while USB is suspended, to prevent immediate reconnect attempts during sleep.
## Expected Behavior
- When the host suspends (S3/suspend-to-RAM), the controller disconnects and can sleep.
- On resume, normal reconnect behavior continues.
