### PR TITLE
feat: Wake-on-PS-button HID for Windows S3 sleep (-DENABLE_WAKE_HID=ON)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,15 @@ jobs:
           cmake --build build/debug --target ds5-bridge
           cp build/debug/ds5-bridge.uf2 artifacts/ds5-bridge-debug.uf2
 
+      - name: Build wake firmware
+        run: |
+          cmake -S . -B build/wake -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPICO_SDK_PATH="$PICO_SDK_PATH" \
+            -DENABLE_WAKE_HID=ON
+          cmake --build build/wake --target ds5-bridge
+          cp build/wake/ds5-bridge.uf2 artifacts/ds5-bridge-wake.uf2
+
       - name: Upload standard UF2 artifact
         uses: actions/upload-artifact@v7
         with:
@@ -105,5 +114,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           path: artifacts/ds5-bridge-debug.uf2
+          archive: false
+          if-no-files-found: error
+
+      - name: Upload wake UF2 artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: artifacts/ds5-bridge-wake.uf2
           archive: false
           if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,16 @@ target_compile_definitions(ds5-bridge PRIVATE
         ENABLE_VERBOSE=${ENABLE_VERBOSE_VALUE}
 )
 
+option(ENABLE_WAKE_HID "Wake the Windows host on PS-button press" OFF)
+if(ENABLE_WAKE_HID)
+    target_compile_definitions(ds5-bridge PRIVATE
+            ENABLE_WAKE_HID
+    )
+    target_sources(ds5-bridge PRIVATE
+            src/wake.cpp
+    )
+endif()
+
 pico_set_program_name(ds5-bridge "ds5-bridge")
 pico_set_program_version(ds5-bridge "0.5.3")
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ To build the project from source:
 1. Update TinyUSB in the Pico SDK to the latest version
 2. Compile using standard Pico SDK toolchain
 
+## Wake-on-PS (optional)
+
+A `-DENABLE_WAKE_HID=ON` build adds a second HID interface (a boot keyboard) that injects an **F15** keypress when any controller button is pressed while the host is suspended, waking the PC from **S3 sleep**. F15 was chosen because it has no default Windows or app binding — a stray fire never inserts characters or triggers shortcuts.
+
+Scope: **S3 only.** Modern Standby (S0ix) is not supported. To check your machine, run `powercfg /a` — you need "Standby (S3)" listed under available sleep states.
+
+After flashing the wake build:
+
+1. Open Device Manager → the new **HID Keyboard Device** (and its parent **USB Composite Device**) → Properties → Power Management → tick **"Allow this device to wake the computer."**
+2. Verify with `powercfg /devicequery wake_armed`.
+3. Sleep the PC; press any button on the controller; the PC should wake within ~1 s.
+4. After a wake, `powercfg /lastwake` should attribute the wake to the HID Keyboard Device.
+
 ## Roadmap
 - Please check out [DS5Dongle plan](https://github.com/users/awalol/projects/5)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,23 +85,27 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
             set_headset(data[56] & 1);
         }
 
+        // Wake-on-PS must observe every BT input report regardless of polling
+        // mode: the wake feature has its own state to maintain (button-byte
+        // diff for edge detection) and short-circuiting it on non-2 polling
+        // modes silently breaks wake while the host is suspended.
+        wake_on_bt_input(data + 3, len - 3);
+
         if (get_config().polling_rate_mode != 2) {
             memcpy(interrupt_in_data, data + 3, 63);
             return;
         }
 
         // We add the critical section here to avoid any race conditions when writing to the interrupt_in_data buffer,
-        // which is shared between the main loop and this callback. 
-        // The critical section ensures that only one thread can access the buffer at a time, 
-        // preventing data corruption and ensuring thread safety.   
+        // which is shared between the main loop and this callback.
+        // The critical section ensures that only one thread can access the buffer at a time,
+        // preventing data corruption and ensuring thread safety.
         // We also set the report_dirty flag to true to indicate that new data is available
         //  and needs to be sent in the next interrupt report.
         critical_section_enter_blocking(&report_cs);
         memcpy(interrupt_in_data, data + 3, 63);
         report_dirty = true;
         critical_section_exit(&report_cs);
-
-        wake_on_bt_input(data + 3, len - 3);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "utils.h"
 #include "resample.h"
 #include "audio.h"
+#include "wake.h"
 #include "hardware/clocks.h"
 #include "hardware/vreg.h"
 #include "hardware/watchdog.h"
@@ -99,6 +100,8 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
         memcpy(interrupt_in_data, data + 3, 63);
         report_dirty = true;
         critical_section_exit(&report_cs);
+
+        wake_on_bt_input(data + 3, len - 3);
     }
 }
 
@@ -107,6 +110,15 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
 // Return zero will cause the stack to STALL request
 uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t *buffer,
                                uint16_t reqlen) {
+#ifdef ENABLE_WAKE_HID
+    if (itf == 1) {
+        if (reqlen >= 8) {
+            memset(buffer, 0, 8);
+            return 8;
+        }
+        return 0;
+    }
+#endif
     (void) itf;
     (void) report_id;
     (void) report_type;
@@ -142,6 +154,12 @@ bool tud_audio_set_itf_cb(uint8_t rhport, tusb_control_request_t const *p_reques
 // received data on OUT endpoint ( Report ID = 0, Type = 0 )
 void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer,
                            uint16_t bufsize) {
+#ifdef ENABLE_WAKE_HID
+    if (itf == 1) {
+        // Drop keyboard SET_REPORT (host LED state).
+        return;
+    }
+#endif
     (void) itf;
     (void) report_id;
     (void) report_type;
@@ -229,6 +247,7 @@ int main() {
 
     // Initialize the critical section for the report buffer
     critical_section_init(&report_cs);
+    wake_init();
 
     config_load();
 
@@ -247,6 +266,7 @@ int main() {
 #endif
         cyw43_arch_poll();
         tud_task();
+        wake_task();
         audio_loop();
         interrupt_loop();
     }

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -96,7 +96,11 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_AUDIO             1
+#ifdef ENABLE_WAKE_HID
+#define CFG_TUD_HID               2
+#else
 #define CFG_TUD_HID               1
+#endif
 #define CFG_TUD_CDC               ENABLE_SERIAL
 #define CFG_TUD_MSC               0
 #define CFG_TUD_MIDI              0

--- a/src/usb_descriptors.cpp
+++ b/src/usb_descriptors.cpp
@@ -47,6 +47,9 @@ enum {
     ITF_NUM_CDC,
     ITF_NUM_CDC_DATA,
 #endif
+#ifdef ENABLE_WAKE_HID
+    ITF_NUM_HID_KBD,
+#endif
     ITF_NUM_TOTAL,
 
     CONFIG_DESC_LEN_AUDIO_IAD =
@@ -56,7 +59,15 @@ enum {
         0,
 #endif
     CONFIG_DESC_LEN_BASE = 0x00E3 + CONFIG_DESC_LEN_AUDIO_IAD,
-    CONFIG_DESC_LEN_TOTAL = CONFIG_DESC_LEN_BASE
+    // Keyboard interface adds 25 bytes:
+    //   9 (interface) + 9 (HID class) + 7 (EP IN) = 25
+    CONFIG_DESC_LEN_WAKE_KBD =
+#ifdef ENABLE_WAKE_HID
+        25,
+#else
+        0,
+#endif
+    CONFIG_DESC_LEN_TOTAL = CONFIG_DESC_LEN_BASE + CONFIG_DESC_LEN_WAKE_KBD
 #if ENABLE_SERIAL
         + TUD_CDC_DESC_LEN
 #endif
@@ -125,7 +136,11 @@ uint8_t descriptor_configuration[] = {
     ITF_NUM_TOTAL, // bNumInterfaces
     0x01, // bConfigurationValue: 1
     0x00, // iConfiguration: 0
+#ifdef ENABLE_WAKE_HID
+    0xE0, // bmAttributes: SELF-POWERED + REMOTE-WAKEUP
+#else
     0xC0, // bmAttributes: SELF-POWERED, NO REMOTE-WAKEUP
+#endif
     0xFA, // bMaxPower: 500mA (250 * 2mA)
 
 #if ENABLE_SERIAL
@@ -384,6 +399,37 @@ uint8_t descriptor_configuration[] = {
 #if ENABLE_SERIAL
     // --- CDC ACM (USB Serial) ---
     TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, STRID_CDC, 0x85, 0x08, 0x06, 0x86, 0x40),
+#endif
+#ifdef ENABLE_WAKE_HID
+    // --- INTERFACE DESCRIPTOR (HID Boot Keyboard, wake key only) ---
+    // EP IN 0x87 (chosen to avoid collision with CDC notification EP 0x85
+    // when ENABLE_SERIAL is also defined).
+    0x09, // bLength
+    0x04, // bDescriptorType (INTERFACE)
+    ITF_NUM_HID_KBD, // bInterfaceNumber
+    0x00, // bAlternateSetting: 0
+    0x01, // bNumEndpoints: 1 (IN only)
+    0x03, // bInterfaceClass: HID
+    0x01, // bInterfaceSubClass: Boot
+    0x01, // bInterfaceProtocol: Keyboard
+    0x00, // iInterface
+
+    // HID Descriptor (keyboard)
+    0x09, // bLength
+    0x21, // bDescriptorType (HID)
+    0x11, 0x01, // bcdHID: 1.11
+    0x00, // bCountryCode
+    0x01, // bNumDescriptors
+    0x22, // bDescriptorType: Report
+    0x2D, 0x00, // wDescriptorLength: 45 (sizeof desc_hid_report_kbd)
+
+    // Endpoint Descriptor (HID IN: EP7)
+    0x07, // bLength
+    0x05, // bDescriptorType (ENDPOINT)
+    0x87, // bEndpointAddress: IN EP7
+    0x03, // bmAttributes: Interrupt
+    0x08, 0x00, // wMaxPacketSize: 8 (boot keyboard report)
+    0x0A, // bInterval: 10ms
 #endif
 };
 
@@ -785,10 +831,45 @@ uint8_t const desc_hid_report_dse[] = {
     // 421 bytes
 };
 
+#ifdef ENABLE_WAKE_HID
+// 41-byte boot-keyboard report descriptor (modifier byte + reserved + 6 keycodes,
+// no Report ID -- boot protocol forbids one and avoids collision with the gamepad's Report ID 1).
+uint8_t const desc_hid_report_kbd[] = {
+    0x05, 0x01,       // Usage Page (Generic Desktop)
+    0x09, 0x06,       // Usage (Keyboard)
+    0xA1, 0x01,       // Collection (Application)
+    0x05, 0x07,       //   Usage Page (Keyboard/Keypad)
+    0x19, 0xE0,       //   Usage Minimum (Left Control)
+    0x29, 0xE7,       //   Usage Maximum (Right GUI)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x25, 0x01,       //   Logical Maximum (1)
+    0x75, 0x01,       //   Report Size (1)
+    0x95, 0x08,       //   Report Count (8)
+    0x81, 0x02,       //   Input (Data,Var,Abs) -- modifier byte
+    0x95, 0x01,       //   Report Count (1)
+    0x75, 0x08,       //   Report Size (8)
+    0x81, 0x01,       //   Input (Const) -- reserved byte
+    0x95, 0x06,       //   Report Count (6)
+    0x75, 0x08,       //   Report Size (8)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x25, 0x65,       //   Logical Maximum (101)
+    0x05, 0x07,       //   Usage Page (Keyboard/Keypad)
+    0x19, 0x00,       //   Usage Minimum (0)
+    0x29, 0x65,       //   Usage Maximum (101)
+    0x81, 0x00,       //   Input (Data,Array) -- 6 keycodes
+    0xC0              // End Collection
+};
+_Static_assert(sizeof(desc_hid_report_kbd) == 45, "keyboard report descriptor length must match wDescriptorLength in config descriptor");
+#endif
+
 // Invoked when received GET HID REPORT DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
 uint8_t const *tud_hid_descriptor_report_cb(uint8_t itf) {
+#ifdef ENABLE_WAKE_HID
+    // HID instance 1 is the wake-only boot keyboard added by ENABLE_WAKE_HID.
+    if (itf == 1) return desc_hid_report_kbd;
+#endif
     (void) itf;
     if (ds_mode()) {
         return desc_hid_report_ds;

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -1,0 +1,146 @@
+//
+// Created by awalol on 2026/4/30.
+//
+
+#include "wake.h"
+
+#ifdef ENABLE_WAKE_HID
+
+#include <cstdio>
+#include <cstring>
+
+#include "tusb.h"
+#include "pico/sync.h"
+#include "pico/time.h"
+
+#define WAKE_KBD_INSTANCE     1
+#define WAKE_KEYCODE_F15      0x68
+#define WAKE_SETTLE_US        20000
+#define WAKE_KEY_HOLD_US      30000
+#define WAKE_KEY_UP_SETTLE_US 10000
+#define WAKE_REQUEST_TIMEOUT_US 5000000
+
+typedef enum {
+    WAKE_IDLE,
+    WAKE_PENDING_PRESS,
+    WAKE_REQUESTED,
+    WAKE_KEY_DOWN,
+    WAKE_KEY_UP_SENT,
+    WAKE_DONE,
+} wake_state_t;
+
+static critical_section_t wake_cs;
+static volatile bool host_suspended = false;
+static volatile bool host_resumed_event = false;
+static wake_state_t state = WAKE_IDLE;
+static uint64_t state_entered_us = 0;
+static uint8_t prev_ps_bit = 1;
+
+static void enter_state(wake_state_t s) {
+    state = s;
+    state_entered_us = time_us_64();
+}
+
+void wake_init(void) {
+    critical_section_init(&wake_cs);
+}
+
+extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
+    (void)remote_wakeup_en;
+    host_suspended = true;
+    if (state == WAKE_IDLE || state == WAKE_DONE) {
+        state = WAKE_PENDING_PRESS;
+        state_entered_us = time_us_64();
+        prev_ps_bit = 1;
+    }
+}
+
+extern "C" void tud_resume_cb(void) {
+    host_suspended = false;
+    host_resumed_event = true;
+}
+
+void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
+    if (len < 9) return;
+    const uint8_t ps_now = hid_input[8] & 0x01;
+
+    critical_section_enter_blocking(&wake_cs);
+    const bool edge = (prev_ps_bit == 0 && ps_now == 1);
+    prev_ps_bit = ps_now;
+    const bool act = edge && state == WAKE_PENDING_PRESS;
+    if (act) {
+        state = WAKE_REQUESTED;
+        state_entered_us = time_us_64();
+    }
+    critical_section_exit(&wake_cs);
+
+    if (act) {
+        // Safe no-op if the host did not enable remote wakeup. We still proceed
+        // through the FSM and try to send the key once the host resumes.
+        tud_remote_wakeup();
+    }
+}
+
+void wake_on_bt_disconnect(void) {
+    critical_section_enter_blocking(&wake_cs);
+    state = WAKE_IDLE;
+    prev_ps_bit = 1;
+    critical_section_exit(&wake_cs);
+}
+
+void wake_task(void) {
+    const uint64_t now = time_us_64();
+
+    critical_section_enter_blocking(&wake_cs);
+    const wake_state_t s = state;
+    const uint64_t entered = state_entered_us;
+    critical_section_exit(&wake_cs);
+
+    switch (s) {
+        case WAKE_IDLE:
+        case WAKE_PENDING_PRESS:
+        case WAKE_DONE:
+            return;
+
+        case WAKE_REQUESTED: {
+            if (host_resumed_event || !host_suspended) {
+                host_resumed_event = false;
+                if (now - entered < WAKE_SETTLE_US) return;
+                if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) return;
+                uint8_t rpt[8] = { 0, 0, WAKE_KEYCODE_F15, 0, 0, 0, 0, 0 };
+                if (tud_hid_n_report(WAKE_KBD_INSTANCE, 0, rpt, sizeof(rpt))) {
+                    critical_section_enter_blocking(&wake_cs);
+                    enter_state(WAKE_KEY_DOWN);
+                    critical_section_exit(&wake_cs);
+                }
+            } else if (now - entered > WAKE_REQUEST_TIMEOUT_US) {
+                critical_section_enter_blocking(&wake_cs);
+                enter_state(WAKE_DONE);
+                critical_section_exit(&wake_cs);
+            }
+            return;
+        }
+
+        case WAKE_KEY_DOWN: {
+            if (now - entered < WAKE_KEY_HOLD_US) return;
+            if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) return;
+            uint8_t up[8] = { 0 };
+            if (tud_hid_n_report(WAKE_KBD_INSTANCE, 0, up, sizeof(up))) {
+                critical_section_enter_blocking(&wake_cs);
+                enter_state(WAKE_KEY_UP_SENT);
+                critical_section_exit(&wake_cs);
+            }
+            return;
+        }
+
+        case WAKE_KEY_UP_SENT: {
+            if (now - entered < WAKE_KEY_UP_SETTLE_US) return;
+            critical_section_enter_blocking(&wake_cs);
+            enter_state(WAKE_DONE);
+            critical_section_exit(&wake_cs);
+            return;
+        }
+    }
+}
+
+#endif // ENABLE_WAKE_HID

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -61,8 +61,14 @@ extern "C" void tud_resume_cb(void) {
 }
 
 void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
-    if (len < 9) return;
-    const uint8_t ps_now = hid_input[8] & 0x01;
+    if (len < 10) return;
+    // DualSense BT 0x31 input report layout (after main.cpp's `data + 3` skip):
+    //   byte 7 low nibble: D-pad direction (0x08 idle); high nibble: face buttons
+    //   byte 8: L1, R1, L2 click, R2 click, share, options, L3, R3
+    //   byte 9: PS (bit 0), touchpad-click (bit 1), mute (bit 2)
+    // The PS bit is at byte 9, not byte 8 (which is L1). Verified by capturing
+    // per-button report deltas with a diagnostic firmware.
+    const uint8_t ps_now = hid_input[9] & 0x01;
 
     critical_section_enter_blocking(&wake_cs);
     const bool edge = (prev_ps_bit == 0 && ps_now == 1);

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -34,7 +34,11 @@ static volatile bool host_suspended = false;
 static volatile bool host_resumed_event = false;
 static wake_state_t state = WAKE_IDLE;
 static uint64_t state_entered_us = 0;
-static uint8_t prev_ps_bit = 1;
+// Last-seen DualSense button bytes. Idle defaults: byte 7 = 0x08 (D-pad
+// released), bytes 8 / 9 = 0 (no shoulders, no PS / touchpad / mute).
+static uint8_t prev_b7 = 0x08;
+static uint8_t prev_b8 = 0x00;
+static uint8_t prev_b9 = 0x00;
 
 static void enter_state(wake_state_t s) {
     state = s;
@@ -51,7 +55,7 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
     if (state == WAKE_IDLE || state == WAKE_DONE) {
         state = WAKE_PENDING_PRESS;
         state_entered_us = time_us_64();
-        prev_ps_bit = 1;
+        prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
     }
 }
 
@@ -66,31 +70,46 @@ void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
     //   byte 7 low nibble: D-pad direction (0x08 idle); high nibble: face buttons
     //   byte 8: L1, R1, L2 click, R2 click, share, options, L3, R3
     //   byte 9: PS (bit 0), touchpad-click (bit 1), mute (bit 2)
-    // The PS bit is at byte 9, not byte 8 (which is L1). Verified by capturing
-    // per-button report deltas with a diagnostic firmware.
-    const uint8_t ps_now = hid_input[9] & 0x01;
+    //
+    // We trigger on ANY change in those three button bytes, not strictly on
+    // the PS bit. Reasons:
+    //   1. The DualSense's BT radio enters a low-power sniff mode after a
+    //      period of inactivity. The PS button alone often does not wake
+    //      the radio out of sniff -- shoulder buttons reliably do. So the
+    //      first BT report after S3 is most likely whichever button the
+    //      user happened to press to wake the radio. PS itself counts as
+    //      "any button" too, so the single-press UX still works.
+    //   2. We additionally call tud_remote_wakeup() speculatively even from
+    //      WAKE_IDLE / WAKE_DONE state. TinyUSB returns true only when the
+    //      host actually USB-suspended the bus; otherwise it's a no-op. This
+    //      protects against the case where tud_suspend_cb didn't fire (e.g.
+    //      a hub between the host and the dongle masking the suspend signal
+    //      from downstream). On success the FSM transitions to REQUESTED and
+    //      proceeds with the keystroke as normal.
+    const uint8_t b7 = hid_input[7];
+    const uint8_t b8 = hid_input[8];
+    const uint8_t b9 = hid_input[9];
 
     critical_section_enter_blocking(&wake_cs);
-    const bool edge = (prev_ps_bit == 0 && ps_now == 1);
-    prev_ps_bit = ps_now;
-    const bool act = edge && state == WAKE_PENDING_PRESS;
-    if (act) {
-        state = WAKE_REQUESTED;
-        state_entered_us = time_us_64();
-    }
+    const bool changed = (b7 != prev_b7) || (b8 != prev_b8) || (b9 != prev_b9);
+    const bool armable = (state == WAKE_IDLE || state == WAKE_DONE || state == WAKE_PENDING_PRESS);
+    prev_b7 = b7; prev_b8 = b8; prev_b9 = b9;
     critical_section_exit(&wake_cs);
 
-    if (act) {
-        // Safe no-op if the host did not enable remote wakeup. We still proceed
-        // through the FSM and try to send the key once the host resumes.
-        tud_remote_wakeup();
+    if (changed && armable) {
+        if (tud_remote_wakeup()) {
+            critical_section_enter_blocking(&wake_cs);
+            state = WAKE_REQUESTED;
+            state_entered_us = time_us_64();
+            critical_section_exit(&wake_cs);
+        }
     }
 }
 
 void wake_on_bt_disconnect(void) {
     critical_section_enter_blocking(&wake_cs);
     state = WAKE_IDLE;
-    prev_ps_bit = 1;
+    prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
     critical_section_exit(&wake_cs);
 }
 

--- a/src/wake.h
+++ b/src/wake.h
@@ -1,0 +1,22 @@
+//
+// Created by awalol on 2026/4/30.
+//
+
+#ifndef DS5_BRIDGE_WAKE_H
+#define DS5_BRIDGE_WAKE_H
+
+#include <cstdint>
+
+#ifdef ENABLE_WAKE_HID
+void wake_init(void);
+void wake_on_bt_input(const uint8_t *hid_input, uint16_t len);
+void wake_on_bt_disconnect(void);
+void wake_task(void);
+#else
+static inline void wake_init(void) {}
+static inline void wake_on_bt_input(const uint8_t *, uint16_t) {}
+static inline void wake_on_bt_disconnect(void) {}
+static inline void wake_task(void) {}
+#endif
+
+#endif //DS5_BRIDGE_WAKE_H


### PR DESCRIPTION
Closes #47 (controller-triggered PC wake from sleep), addresses #6 in spirit (USB remote-wakeup is the standard Windows-side equivalent of WoL for HID-class devices).

> ⚠️ **For this feature to actually fire on most Windows machines, see the follow-up PR https://github.com/awalol/DS5Dongle/pull/61**, which adds a Microsoft OS 2.0 descriptor that tells Windows to selectively-suspend our audio function. Without that descriptor, Windows audio engine policy keeps the dongle at D0 throughout S3 → bus never enters USB suspend → `tud_remote_wakeup()` is refused → no wake fires. **Both PRs together** are the working feature; this PR alone has the firmware path but no way to actually engage it on a real Win11 box.

## Summary

Adds an opt-in `-DENABLE_WAKE_HID=ON` build flavor:
- TinyUSB exposes a **second HID interface** (boot keyboard, EP `0x87`) alongside the existing gamepad on interface 3.
- Configuration descriptor advertises **remote-wakeup capability** (`bmAttributes` `0xC0` → `0xE0`).
- New `src/wake.{cpp,h}` implements an FSM (IDLE → PENDING_PRESS → REQUESTED → KEY_DOWN → KEY_UP_SENT → DONE) that, while the host is suspended, watches BT input reports for a controller button-state change, calls `tud_remote_wakeup()`, then sends a synthetic **F15 keypress** to keep Windows from immediately re-suspending.
- Default build is byte-for-byte identical to the previous `master` tip — entire feature is behind `ENABLE_WAKE_HID`.
- CI builds a third UF2 artifact `ds5-bridge-wake.uf2` alongside `ds5-bridge.uf2` and `ds5-bridge-dse.uf2`. DSE+wake combo is intentionally not built.

### Why F15
No default Windows or app binding — a stray fire never inserts characters or triggers shortcuts. Conventional KVM / presentation-tool choice for "innocuous wake key."

### Why "any button" trigger and not strict PS
Sony's controller firmware puts the BT radio into a low-power sniff mode after inactivity. PS button alone often doesn't wake the radio out of sniff — shoulder buttons reliably do. Triggering on any change in the button bytes (D-pad nibble + face buttons + shoulders + select + PS/touchpad/mute) is robust to whichever button the user happens to press to wake the controller. PS itself counts, so the documented PS-press UX still works.

The implementation also calls `tud_remote_wakeup()` speculatively even from `WAKE_IDLE`/`WAKE_DONE`, not only after `tud_suspend_cb` has fired. TinyUSB returns `true` only when the host actually USB-suspended the bus (otherwise no-op). Protects against `tud_suspend_cb` not being delivered (e.g. some powered hubs mask suspend signals from downstream).

## Scope

**S3 only.** Modern Standby (S0ix) is out of scope; behavior on S0ix laptops is undefined.

## User-side setup (also documented in README)

After flashing the wake build:
1. Device Manager → new "HID Keyboard Device" → Properties → Power Management → tick **"Allow this device to wake the computer."** Repeat on the parent USB Composite Device if needed.
2. `powercfg /devicequery wake_armed` should list the keyboard.
3. Sleep the PC; press any controller button; PC should wake within ~1 s.
4. After wake, `powercfg /lastwake` should attribute the wake to the HID Keyboard Device.

## Commits in this PR (5)

1. `feat: optional wake-on-PS-button HID for Windows S3 sleep` — initial implementation (CMake option, descriptor changes, wake.cpp/h FSM).
2. `ci+docs: build ds5-bridge-wake.uf2 and document Wake-on-PS` — CI artifact + README section.
3. `fix: PS button is at hid_input[9] bit 0, not [8] bit 0` — bit-position fix verified via per-button report capture against a diagnostic firmware.
4. `feat: wake on any controller button + speculative remote-wakeup` — broader trigger and hub-suspend-masking robustness.
5. `fix: call wake_on_bt_input on all polling modes, not only mode 2` — found during testing against current `master` (which now has the `cmd: poll rate switch` work). The wake feature must observe every report regardless of polling mode.

## Test plan (executed on Windows 11, RP2350 Pico2W)

- Both `-DENABLE_WAKE_HID=OFF` and `-DENABLE_WAKE_HID=ON` builds compile clean. ✅
- USBView / `lsusb -v -d 054c:0ce6` shows: `bmAttributes 0xE0`, `bNumInterfaces 5`, interface 4 = HID Boot Keyboard subclass 1 protocol 1, EP `0x87` IN interrupt 8/10. ✅
- Pair a DualSense; normal gameplay still works in Game Controllers panel and Steam Big Picture (Steam fingerprint preserved — VID/PID unchanged). ✅
- Open Notepad, sleep PC (S3, confirmed via `powercfg /a`). Press any controller button. PC wakes (with the follow-up `wake-mso2` PR applied — see note above). ✅
- Sleep / wake cycle repeats reliably (FSM re-arms on next `tud_suspend_cb`). ✅
- Host awake, mash PS 20 times in Notepad / browser address bar / password field — no character insertion. ✅
- Watchdog stress: hammer PS for 60 s → no `Rebooted by Watchdog!`. ✅

## Notable choices

- **Endpoint `0x87`** for the keyboard IN endpoint was chosen to avoid colliding with the CDC notification EP `0x85` introduced by upstream's `ENABLE_SERIAL` work.
- **`bcdUSB` and `bmAttributes` flips are conditional** on `ENABLE_WAKE_HID` — default builds are unchanged.
- **No DSE+wake combo builds** in CI by design, to keep the artifact matrix small.

## Limitations

- Modern Standby (S0ix) machines: not supported.
- Without the follow-up `wake-mso2` PR, Windows generally won't selectively-suspend the device because of the audio class — meaning the wake mechanism never engages even though all firmware paths are in place.
