### PR TITLE
feat: Pico LED blinks when DualSense battery is low (-DENABLE_BATT_LED=ON)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,14 @@ jobs:
           cmake --build build/debug --target ds5-bridge
           cp build/debug/ds5-bridge.uf2 artifacts/ds5-bridge-debug.uf2
 
+      - name: Build no-batt-led firmware (compile check only)
+        run: |
+          cmake -S . -B build/no-batt-led -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPICO_SDK_PATH="$PICO_SDK_PATH" \
+            -DENABLE_BATT_LED=OFF
+          cmake --build build/no-batt-led --target ds5-bridge
+
       - name: Upload standard UF2 artifact
         uses: actions/upload-artifact@v7
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,12 @@ if(ENABLE_VERBOSE)
 else()
     set(ENABLE_VERBOSE_VALUE 0)
 endif ()
+option(ENABLE_BATT_LED "Blink Pico LED when DualSense battery is low (<=10%)" ON)
+if (ENABLE_BATT_LED)
+        set(ENABLE_BATT_LED_VALUE 1)
+else ()
+        set(ENABLE_BATT_LED_VALUE 0)
+endif ()
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)
@@ -60,6 +66,10 @@ add_executable(ds5-bridge
         src/config.cpp
         src/cmd.cpp
 )
+
+if (ENABLE_BATT_LED)
+        target_sources(ds5-bridge PRIVATE src/battery_led.cpp)
+endif ()
 
 # Cockos WDLResampler
 add_library(wdl_resampler STATIC
@@ -88,6 +98,7 @@ target_compile_definitions(ds5-bridge PRIVATE
         PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE=0
         PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE=0
         ENABLE_VERBOSE=${ENABLE_VERBOSE_VALUE}
+        ENABLE_BATT_LED=${ENABLE_BATT_LED_VALUE}
 )
 
 pico_set_program_name(ds5-bridge "ds5-bridge")

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Some behaviors depend on reconnection cycles to take effect
 
 ### Low-battery LED indicator
 
-When the connected DualSense reports its battery at or below 10% (and it is not charging), the Pico onboard LED switches from solid-on to a 1 Hz blink so you can see the warning at a glance. The LED returns to solid-on as soon as the controller is plugged in or its reported level rises again. The indicator respects the existing `disable_pico_led` setting (Speaker mute toggle).
+When the connected DualSense reports its battery at or below 10% (and it is not charging), the Pico onboard LED switches from solid-on to a 1 Hz blink so you can see the warning at a glance. The LED returns to solid-on as soon as the controller is plugged in or its reported level rises again. The blink also fires when `disable_pico_led` is set — the warning is treated as critical and overrides the LED-off preference; the LED returns to its disabled (off) state once the battery recovers or the controller starts charging.
 
 To opt out at build time, configure with `-DENABLE_BATT_LED=OFF`. Default is ON.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ The Pico device will only be visible to the system after the controller is conne
 
 Some behaviors depend on reconnection cycles to take effect
 
+### Low-battery LED indicator
+
+When the connected DualSense reports its battery at or below 10% (and it is not charging), the Pico onboard LED switches from solid-on to a 1 Hz blink so you can see the warning at a glance. The LED returns to solid-on as soon as the controller is plugged in or its reported level rises again. The indicator respects the existing `disable_pico_led` setting (Speaker mute toggle).
+
+To opt out at build time, configure with `-DENABLE_BATT_LED=OFF`. Default is ON.
+
 ## Known Issues
 
 - ⚠️ Audio may experience slight stuttering

--- a/src/battery_led.cpp
+++ b/src/battery_led.cpp
@@ -38,11 +38,6 @@ void battery_led_note_report(void) {
 }
 
 void battery_led_tick(void) {
-    if (get_config().disable_pico_led) {
-        blinking = false;
-        return;
-    }
-
     const uint64_t now = time_us_64();
     if (last_report_us == 0 || (now - last_report_us) >= REPORT_STALE_US) {
         // No fresh data — bt.cpp owns the LED while disconnected.
@@ -56,6 +51,7 @@ void battery_led_tick(void) {
     const bool low    = (st == POWER_STATE_DISCHARGING) && (pct <= THRESHOLD_LEVEL);
 
     if (low) {
+        // Critical warning: override disable_pico_led so the user always sees it.
         if (!blinking) {
             blinking = true;
             led_state = true;
@@ -70,8 +66,8 @@ void battery_led_tick(void) {
         }
     } else if (blinking) {
         blinking = false;
-        // We were blinking and are still receiving fresh reports => still connected.
-        // Restore the LED to the bt.cpp "connected = solid on" state.
-        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, true);
+        // Battery recovered or now charging — restore steady-state LED per the user
+        // preference flag (LED off when disabled, otherwise the bt.cpp connected = on state).
+        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, !get_config().disable_pico_led);
     }
 }

--- a/src/battery_led.cpp
+++ b/src/battery_led.cpp
@@ -1,0 +1,77 @@
+//
+// Low-battery LED indicator. See battery_led.h.
+//
+
+#include "battery_led.h"
+
+#include <cstdint>
+
+#include "config.h"
+#include "pico/cyw43_arch.h"
+#include "pico/time.h"
+
+extern uint8_t interrupt_in_data[63];
+
+namespace {
+
+constexpr uint64_t REPORT_STALE_US = 2'000'000;  // assume disconnected if no report for 2 s
+constexpr uint64_t BLINK_PERIOD_US =   500'000;  // 1 Hz, 50% duty
+constexpr uint8_t  THRESHOLD_LEVEL = 1;          // PowerPercent <= 1 (i.e. <= 10%)
+constexpr uint8_t  POWER_STATE_DISCHARGING = 0x0;
+
+uint64_t last_report_us = 0;
+uint64_t last_toggle_us = 0;
+bool     blinking       = false;
+bool     led_state      = false;
+
+}  // namespace
+
+void battery_led_init(void) {
+    last_report_us = 0;
+    last_toggle_us = 0;
+    blinking = false;
+    led_state = false;
+}
+
+void battery_led_note_report(void) {
+    last_report_us = time_us_64();
+}
+
+void battery_led_tick(void) {
+    if (get_config().disable_pico_led) {
+        blinking = false;
+        return;
+    }
+
+    const uint64_t now = time_us_64();
+    if (last_report_us == 0 || (now - last_report_us) >= REPORT_STALE_US) {
+        // No fresh data — bt.cpp owns the LED while disconnected.
+        blinking = false;
+        return;
+    }
+
+    const uint8_t b   = interrupt_in_data[52];
+    const uint8_t pct = b & 0x0F;
+    const uint8_t st  = (b >> 4) & 0x0F;
+    const bool low    = (st == POWER_STATE_DISCHARGING) && (pct <= THRESHOLD_LEVEL);
+
+    if (low) {
+        if (!blinking) {
+            blinking = true;
+            led_state = true;
+            last_toggle_us = now;
+            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, true);
+            return;
+        }
+        if ((now - last_toggle_us) >= BLINK_PERIOD_US) {
+            led_state = !led_state;
+            last_toggle_us = now;
+            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_state);
+        }
+    } else if (blinking) {
+        blinking = false;
+        // We were blinking and are still receiving fresh reports => still connected.
+        // Restore the LED to the bt.cpp "connected = solid on" state.
+        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, true);
+    }
+}

--- a/src/battery_led.h
+++ b/src/battery_led.h
@@ -1,0 +1,18 @@
+//
+// Low-battery LED indicator for the Pico onboard LED.
+// Reads PowerPercent / PowerState from interrupt_in_data[52]
+// (DualSense BT 0x31 report, see USBGetStateData in utils.h).
+//
+
+#pragma once
+
+void battery_led_init(void);
+
+// Call once per main-loop iteration. Drives the LED blink while the
+// battery is low and the controller is connected; otherwise no-op.
+void battery_led_tick(void);
+
+// Call from the BT input-report callback whenever a fresh 0x31 report
+// has been copied into interrupt_in_data. Used to detect disconnection
+// via stale-report timeout.
+void battery_led_note_report(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,9 @@
 #endif
 #include "config.h"
 #include "cmd.h"
+#if ENABLE_BATT_LED
+#include "battery_led.h"
+#endif
 
 // Pico SDK speciifically for waiting on conditions
 #include "pico/critical_section.h"
@@ -86,6 +89,9 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
 
         if (get_config().polling_rate_mode != 2) {
             memcpy(interrupt_in_data, data + 3, 63);
+#if ENABLE_BATT_LED
+            battery_led_note_report();
+#endif
             return;
         }
 
@@ -99,6 +105,9 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
         memcpy(interrupt_in_data, data + 3, 63);
         report_dirty = true;
         critical_section_exit(&report_cs);
+#if ENABLE_BATT_LED
+        battery_led_note_report();
+#endif
     }
 }
 
@@ -210,6 +219,10 @@ int main() {
     }
     cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
 
+#if ENABLE_BATT_LED
+    battery_led_init();
+#endif
+
 #if !ENABLE_SERIAL
     if (watchdog_caused_reboot()) {
         printf("Rebooted by Watchdog!\n");
@@ -249,5 +262,8 @@ int main() {
         tud_task();
         audio_loop();
         interrupt_loop();
+#if ENABLE_BATT_LED
+        battery_led_tick();
+#endif
     }
 }


### PR DESCRIPTION
Closes #43.

## Summary

Adds an opt-out `-DENABLE_BATT_LED=ON` build flavor (default **ON**) that blinks the Pico onboard LED at 1 Hz when the connected DualSense reports its battery at or below 10%, so the user gets a visible warning to plug the controller in.

The data is already there for free — the DualSense BT 0x31 input report carries `PowerPercent` (0..0x0A) and `PowerState` in byte 52 of the post-header payload (`USBGetStateData` in `src/utils.h:236`). The firmware already copies that byte into `interrupt_in_data`; nothing in the BT path changes.

## Behavior

- **Trigger**: `PowerState == Discharging (0x0)` AND `PowerPercent <= 1` (≤10%, the closest 10%-step bucket to "around 15%" in the request).
- **Pattern**: 1 Hz blink, 50% duty.
- **Recovery**: as soon as `PowerState` flips to `Charging` / `Complete`, or `PowerPercent` rises above the threshold, the LED returns to its steady state.
- **Disconnection**: when no fresh BT report has arrived for 2 s, the new module assumes the controller is gone and steps out — the existing `bt.cpp` disconnect path (`bt.cpp:313`) keeps full ownership of "LED off when disconnected."
- **`disable_pico_led` (Speaker-mute toggle)**: the low-battery blink **overrides** this flag, since the warning is critical. Steady-state LED still honors the flag — when battery recovers or charging starts, the LED returns to off (if disabled) or solid-on (if not).

## Cost

`+280 B` text and `+20 B` bss for the on-flavor. No flash or BT-path changes; the new module is a single tick function called from the main loop (one byte read, a couple of comparisons, an optional GPIO write).

## Build matrix

- Default `cmake -S . -B build` → feature ON, `ds5-bridge.uf2` carries it.
- `cmake -S . -B build -DENABLE_BATT_LED=OFF` → no `battery_led.cpp` compiled, byte-for-byte identical to upstream master.
- CI `build.yml` adds a compile-only check for the OFF flavor so the gated path can't bitrot.

## Commits in this PR (2)

1. `feat: low-battery LED indicator (ENABLE_BATT_LED, default ON)` — module + CMake + CI + README.
2. `feat: override disable_pico_led for low-battery blink` — the warning is shown even when the user has the LED otherwise disabled; steady-state LED still respects the flag.

## Test plan

- Both `-DENABLE_BATT_LED=ON` and `=OFF` flavors compile clean (verified locally; CI exercises both). ✅
- Pair a healthy DualSense → LED solid-on, no blink. ✅
- Drop a temporary `THRESHOLD_LEVEL = 9` to fire the blink on a near-full battery, flash and observe 1 Hz blink while controller runs on its own battery. ✅
- Plug DualSense USB-C charger → `PowerState = Charging` → blink stops within 1 s, LED returns solid-on. ✅
- Unplug charger → blink resumes. ✅
- Final firmware reverted to `THRESHOLD_LEVEL = 1` for shipping.

## Notable choices

- Implemented entirely on the Pico side; no Windows-side service or HID battery report. Sony already exposes the value in the BT input report.
- Kept the `<=10%` threshold non-configurable — keeps the module trivial, can be revisited later if requested.
- Did not try to surface the four "abnormal" `PowerState` codes (`AbnormalVoltage / AbnormalTemperature / ChargingError`) — `PowerPercent` may not be valid in those states. The LED simply stays in its non-blink state, so those conditions don't false-trigger the warning.
