### PR TITLE
fix(wake): wake-from-S3 after controller off, plus wake-and-resleep retry

### DIFF
--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -305,7 +305,12 @@ static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
         }
 
         case HCI_EVENT_DISCONNECTION_COMPLETE: {
-#if !ENABLE_SERIAL
+#if !ENABLE_SERIAL && !defined(ENABLE_WAKE_HID)
+            // Without ENABLE_WAKE_HID we hide the USB device whenever no
+            // controller is paired (upstream behavior). With wake enabled
+            // we must stay on the bus across controller power-cycles, so
+            // tud_suspend_cb can later fire and tud_remote_wakeup() can
+            // signal a wake when the controller is turned back on.
             tud_disconnect();
 #endif
             gap_connectable_control(1);

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -15,10 +15,15 @@
 
 #define WAKE_KBD_INSTANCE     1
 #define WAKE_KEYCODE_F15      0x68
-#define WAKE_SETTLE_US        20000
-#define WAKE_KEY_HOLD_US      30000
-#define WAKE_KEY_UP_SETTLE_US 10000
+// Post-resume timings tuned for "wake-and-resleep" Windows behavior: the host
+// resumes USB, but if no HID input is consumed during the brief wake window
+// the system can re-suspend within ~1 s. Bigger settles + a second F15 give
+// Windows multiple polling cycles to pick the keystroke up.
+#define WAKE_SETTLE_US        150000   // 150 ms — let host finish USB re-init
+#define WAKE_KEY_HOLD_US       80000   // 80 ms keydown -> keyup gap
+#define WAKE_KEY_UP_SETTLE_US 200000   // 200 ms between attempts (or before DONE)
 #define WAKE_REQUEST_TIMEOUT_US 5000000
+#define WAKE_KEY_ATTEMPTS     2
 
 #ifdef WAKE_DEBUG
 #  define WAKE_DBG(fmt, ...) printf("[wake] " fmt "\n", ##__VA_ARGS__)
@@ -51,6 +56,7 @@ static volatile bool host_suspended = false;
 static volatile bool host_resumed_event = false;
 static wake_state_t state = WAKE_IDLE;
 static uint64_t state_entered_us = 0;
+static uint8_t key_attempts = 0;
 // Last-seen DualSense button bytes. Idle defaults: byte 7 = 0x08 (D-pad
 // released), bytes 8 / 9 = 0 (no shoulders, no PS / touchpad / mute).
 static uint8_t prev_b7 = 0x08;
@@ -74,6 +80,7 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
         state = WAKE_PENDING_PRESS;
         state_entered_us = time_us_64();
         prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
+        key_attempts = 0;
         WAKE_DBG("-> PENDING_PRESS");
     }
 }
@@ -130,7 +137,7 @@ void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
             static uint64_t last_log = 0;
             const uint64_t now = time_us_64();
             if (now - last_log > 5000000) {
-                WAKE_DBG("button event, tud_remote_wakeup()=0 (host awake or wake disabled) -- 5s heartbeat");
+                WAKE_DBG("button event, tud_remote_wakeup()=0 (USB bus not in suspend) -- 5s heartbeat");
                 last_log = now;
             }
         }
@@ -182,7 +189,7 @@ void wake_task(void) {
                     critical_section_exit(&wake_cs);
                 }
             } else if (now - entered > WAKE_REQUEST_TIMEOUT_US) {
-                WAKE_DBG("REQUESTED timeout 5s -> DONE (host never resumed)");
+                WAKE_DBG("REQUESTED timeout 5s -> DONE (no resume signaling; may have already woken)");
                 critical_section_enter_blocking(&wake_cs);
                 enter_state(WAKE_DONE);
                 critical_section_exit(&wake_cs);
@@ -215,10 +222,39 @@ void wake_task(void) {
 
         case WAKE_KEY_UP_SENT: {
             if (now - entered < WAKE_KEY_UP_SETTLE_US) return;
-            WAKE_DBG("KEY_UP_SENT settle done -> DONE");
-            critical_section_enter_blocking(&wake_cs);
-            enter_state(WAKE_DONE);
-            critical_section_exit(&wake_cs);
+            key_attempts++;
+            if (key_attempts < WAKE_KEY_ATTEMPTS) {
+                // Retry: do NOT re-enter WAKE_REQUESTED (which gates on a
+                // fresh tud_resume_cb event). We already established the
+                // host woke once; just send another keydown directly. If the
+                // host has dipped back into suspend, tud_hid_n_ready will be
+                // false and we'll heartbeat from KEY_DOWN until it returns.
+                if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) {
+#ifdef WAKE_DEBUG
+                    static uint64_t last_log = 0;
+                    if (now - last_log > 1000000) {
+                        WAKE_DBG("KEY_UP_SENT retry waiting: hid_n_ready=0 (heartbeat 1Hz)");
+                        last_log = now;
+                    }
+#endif
+                    return;
+                }
+                uint8_t rpt[8] = { 0, 0, WAKE_KEYCODE_F15, 0, 0, 0, 0, 0 };
+                const bool sent = tud_hid_n_report(WAKE_KBD_INSTANCE, 0, rpt, sizeof(rpt));
+                WAKE_DBG("KEY_UP_SENT: retrying F15 (attempt %d/%d) -> %d",
+                         (int)key_attempts + 1, (int)WAKE_KEY_ATTEMPTS, (int)sent);
+                if (sent) {
+                    critical_section_enter_blocking(&wake_cs);
+                    enter_state(WAKE_KEY_DOWN);
+                    critical_section_exit(&wake_cs);
+                }
+            } else {
+                WAKE_DBG("KEY_UP_SENT settle done -> DONE");
+                critical_section_enter_blocking(&wake_cs);
+                enter_state(WAKE_DONE);
+                key_attempts = 0;
+                critical_section_exit(&wake_cs);
+            }
             return;
         }
     }


### PR DESCRIPTION
Fixes two related real-world failure modes of the Wake-on-PS feature on Windows S3 sleep that I hit during follow-up testing of #60 / #61.

## Failure mode A — controller off while host sleeps

**Repro**: pair DualSense, sleep PC, press button → wake (works ✅). After wake, long-press PS to turn off the controller, then sleep PC, then turn controller back on and press a button.

**Observed**: nothing wakes. The dongle's UART shows BT inquiry running, then BT reconnect with `Init DualSense`, then `[wake] button event` with `tud_remote_wakeup()=0` heartbeats — TinyUSB reports the bus was never in suspend.

**Cause**: `bt.cpp` calls `tud_disconnect()` on every `HCI_EVENT_DISCONNECTION_COMPLETE`, which drops the USB pullup as soon as the controller turns off. So by the time the PC enters S3 the dongle is already gone from the bus — `tud_suspend_cb` never fires because there is no USB device on the bus to suspend. Later, `tud_connect()` runs when BT re-pairs, but the host's USB controller is itself in S3 and a new device appearing on a suspended root port is not a default wake source.

**Fix**: when `ENABLE_WAKE_HID` is on, do not disconnect from USB on BT disconnect. Stay on the bus across controller power-cycles so the host can suspend us and we can later signal remote wakeup.

```c
case HCI_EVENT_DISCONNECTION_COMPLETE: {
#if !ENABLE_SERIAL && !defined(ENABLE_WAKE_HID)
    tud_disconnect();
#endif
    ...
}
```

Tradeoff: with wake enabled, the dongle stays in Device Manager when no controller is paired (where today it disappears). For users who don't enable wake, behavior is unchanged.

## Failure mode B — wake-and-resleep

**Repro** (with fix A applied): same scenario as A, but now `tud_suspend_cb` fires correctly, `tud_remote_wakeup()=1`, the FSM sends the F15 keydown — yet the PC stays asleep visibly. Event Viewer logs a `Power-Troubleshooter` "system has returned from low power state" event (so the kernel did briefly transition out of S3), but `powercfg /lastwake` never updates and the system re-suspends within ~1 second.

**Cause**: with the current 20 ms post-resume settle and 30 ms key-hold, the F15 keystroke lands in the dongle's HID endpoint buffer **before** Windows has finished re-initializing the USB stack on resume. The keystroke is then discarded along with the brief wake, and Windows treats the resume as spurious and re-suspends. The FSM thinks it succeeded (`tud_hid_n_report()=1` just means the report queued device-side).

**Fix**: longer post-resume settle (150 ms), longer key-hold (80 ms), and a second F15 attempt 200 ms later. With two attempts spaced across a full polling window, at least one is consumed during the wake.

```c
#define WAKE_SETTLE_US        150000   // 150 ms
#define WAKE_KEY_HOLD_US       80000   // 80 ms
#define WAKE_KEY_UP_SETTLE_US 200000   // 200 ms
#define WAKE_KEY_ATTEMPTS     2
```

The retry path sends the second keydown **directly** from `WAKE_KEY_UP_SENT` rather than re-entering `WAKE_REQUESTED`, because `WAKE_REQUESTED` gates on a fresh `tud_resume_cb` event — once the first wake fired, that event is stale and re-entering the state would just sit in a 5 s timeout for a resume signal that already happened.

Also corrected the timeout message from "host never resumed" (misleading — the host often *did* resume but we missed the event) to "no resume signaling; may have already woken."

## Test plan (Windows 11, RP2350 Pico2W, real S3)

- Pair DualSense, sleep PC, press button → wake ✅
- After wake, turn off controller, sleep PC, turn controller on, press button → wake ✅ (was broken before this PR)
- Repeat the cycle multiple times back-to-back → wake ✅
- `-DENABLE_WAKE_HID=OFF` build: byte-for-byte identical to master ✅
- Both flavors compile clean ✅

## What I'm not addressing here

- The first BT input report after the controller is turned back on does not trigger wake. That's because powering on the controller consumes the PS-button press internally and the first BT report shows idle buttons — the user has to press a button after the controller boots. Working as designed; documented in code comments.
- Modern Standby (S0ix) machines: still out of scope.

## Commit (1)

`fix(wake): keep USB alive across BT off, retry F15 against wake-and-resleep`
