### PR TITLE
refactor: add SetStateData and audio send priority

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,15 @@ jobs:
           cmake --build build/debug --target ds5-bridge
           cp build/debug/ds5-bridge.uf2 artifacts/ds5-bridge-debug.uf2
 
+      - name: Build wake firmware
+        run: |
+          cmake -S . -B build/wake -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPICO_SDK_PATH="$PICO_SDK_PATH" \
+            -DENABLE_WAKE_HID=ON
+          cmake --build build/wake --target ds5-bridge
+          cp build/wake/ds5-bridge.uf2 artifacts/ds5-bridge-wake.uf2
+
       - name: Upload standard UF2 artifact
         uses: actions/upload-artifact@v7
         with:
@@ -105,5 +114,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           path: artifacts/ds5-bridge-debug.uf2
+          archive: false
+          if-no-files-found: error
+
+      - name: Upload wake UF2 artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: artifacts/ds5-bridge-wake.uf2
           archive: false
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,14 @@ jobs:
           cmake --build build/debug --target ds5-bridge
           cp build/debug/ds5-bridge.uf2 artifacts/ds5-bridge-debug.uf2
 
+      - name: Build no-batt-led firmware (compile check only)
+        run: |
+          cmake -S . -B build/no-batt-led -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPICO_SDK_PATH="$PICO_SDK_PATH" \
+            -DENABLE_BATT_LED=OFF
+          cmake --build build/no-batt-led --target ds5-bridge
+
       - name: Upload standard UF2 artifact
         uses: actions/upload-artifact@v7
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,12 @@ if(ENABLE_VERBOSE)
 else()
     set(ENABLE_VERBOSE_VALUE 0)
 endif ()
+option(ENABLE_BATT_LED "Blink Pico LED when DualSense battery is low (<=10%)" ON)
+if (ENABLE_BATT_LED)
+        set(ENABLE_BATT_LED_VALUE 1)
+else ()
+        set(ENABLE_BATT_LED_VALUE 0)
+endif ()
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)
@@ -60,6 +66,10 @@ add_executable(ds5-bridge
         src/config.cpp
         src/cmd.cpp
 )
+
+if (ENABLE_BATT_LED)
+        target_sources(ds5-bridge PRIVATE src/battery_led.cpp)
+endif ()
 
 # Cockos WDLResampler
 add_library(wdl_resampler STATIC
@@ -88,6 +98,7 @@ target_compile_definitions(ds5-bridge PRIVATE
         PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE=0
         PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE=0
         ENABLE_VERBOSE=${ENABLE_VERBOSE_VALUE}
+        ENABLE_BATT_LED=${ENABLE_BATT_LED_VALUE}
 )
 
 pico_set_program_name(ds5-bridge "ds5-bridge")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,13 @@ if(ENABLE_WAKE_HID)
     )
 endif()
 
+option(WAKE_DEBUG "Print wake-FSM transitions to UART (developer use)" OFF)
+if(WAKE_DEBUG)
+    target_compile_definitions(ds5-bridge PRIVATE
+            WAKE_DEBUG
+    )
+endif()
+
 pico_set_program_name(ds5-bridge "ds5-bridge")
 pico_set_program_version(ds5-bridge "0.5.3")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,16 @@ target_compile_definitions(ds5-bridge PRIVATE
         ENABLE_VERBOSE=${ENABLE_VERBOSE_VALUE}
 )
 
+option(ENABLE_WAKE_HID "Wake the Windows host on PS-button press" OFF)
+if(ENABLE_WAKE_HID)
+    target_compile_definitions(ds5-bridge PRIVATE
+            ENABLE_WAKE_HID
+    )
+    target_sources(ds5-bridge PRIVATE
+            src/wake.cpp
+    )
+endif()
+
 pico_set_program_name(ds5-bridge "ds5-bridge")
 pico_set_program_version(ds5-bridge "0.5.3")
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Some behaviors depend on reconnection cycles to take effect
 
 ### Low-battery LED indicator
 
-When the connected DualSense reports its battery at or below 10% (and it is not charging), the Pico onboard LED switches from solid-on to a 1 Hz blink so you can see the warning at a glance. The LED returns to solid-on as soon as the controller is plugged in or its reported level rises again. The indicator respects the existing `disable_pico_led` setting (Speaker mute toggle).
+When the connected DualSense reports its battery at or below 10% (and it is not charging), the Pico onboard LED switches from solid-on to a 1 Hz blink so you can see the warning at a glance. The LED returns to solid-on as soon as the controller is plugged in or its reported level rises again. The blink also fires when `disable_pico_led` is set — the warning is treated as critical and overrides the LED-off preference; the LED returns to its disabled (off) state once the battery recovers or the controller starts charging.
 
 To opt out at build time, configure with `-DENABLE_BATT_LED=OFF`. Default is ON.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ To build the project from source:
 1. Update TinyUSB in the Pico SDK to the latest version
 2. Compile using standard Pico SDK toolchain
 
+## Wake-on-PS (optional)
+
+A `-DENABLE_WAKE_HID=ON` build adds a second HID interface (a boot keyboard) that injects an **F15** keypress when any controller button is pressed while the host is suspended, waking the PC from **S3 sleep**. F15 was chosen because it has no default Windows or app binding — a stray fire never inserts characters or triggers shortcuts.
+
+Scope: **S3 only.** Modern Standby (S0ix) is not supported. To check your machine, run `powercfg /a` — you need "Standby (S3)" listed under available sleep states.
+
+After flashing the wake build:
+
+1. Open Device Manager → the new **HID Keyboard Device** (and its parent **USB Composite Device**) → Properties → Power Management → tick **"Allow this device to wake the computer."**
+2. Verify with `powercfg /devicequery wake_armed`.
+3. Sleep the PC; press any button on the controller; the PC should wake within ~1 s.
+4. After a wake, `powercfg /lastwake` should attribute the wake to the HID Keyboard Device.
+
 ## Roadmap
 - Please check out [DS5Dongle plan](https://github.com/users/awalol/projects/5)
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ The Pico device will only be visible to the system after the controller is conne
 
 Some behaviors depend on reconnection cycles to take effect
 
+### Low-battery LED indicator
+
+When the connected DualSense reports its battery at or below 10% (and it is not charging), the Pico onboard LED switches from solid-on to a 1 Hz blink so you can see the warning at a glance. The LED returns to solid-on as soon as the controller is plugged in or its reported level rises again. The indicator respects the existing `disable_pico_led` setting (Speaker mute toggle).
+
+To opt out at build time, configure with `-DENABLE_BATT_LED=OFF`. Default is ON.
+
 ## Known Issues
 
 - ⚠️ Audio may experience slight stuttering

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -40,22 +40,6 @@ struct audio_raw_element {
     float data[512 * 2];
 };
 
-uint8_t state_data[63] = {
-    0xfd, 0xf7, 0x0, 0x0,
-    0x7f, 0x7f, // Headphones, Speaker
-    0xff, 0x9, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa,
-    0x7, 0x0, 0x0, 0x2, 0x1,
-    0x00,
-    0xff, 0xd7, 0x00, // RGB LED: R, G, B (Nijika Color!)✨
-};
-
-void set_state_data(const uint8_t* data, const uint8_t len) {
-    memcpy(state_data, data, len);
-}
-
 void set_headset(bool state) {
     plug_headset = state;
 }
@@ -131,22 +115,19 @@ void audio_loop() {
         pkt[8] = buf_len; // 这 4 个字节的作用未知，调整没有效果
         pkt[9] = buf_len; // audio buffer length 只有调整这个字节生效。
         pkt[10] = packetCounter++;
-        pkt[11] = 0x10 | 0 << 6 | 1 << 7;
-        pkt[12] = 63;
-        memcpy(pkt + 13, state_data, sizeof(state_data));
-        pkt[76] = 0x12 | 0 << 6 | 1 << 7;
-        pkt[77] = SAMPLE_SIZE;
-        memcpy(pkt + 78, haptic_buf, SAMPLE_SIZE);
-        pkt[142] = (plug_headset ? 0x16 : 0x13) | 0 << 6 | 1 << 7; // Speaker: 0x13
+        pkt[11] = 0x12 | 0 << 6 | 1 << 7;
+        pkt[12] = SAMPLE_SIZE;
+        memcpy(pkt + 13, haptic_buf, SAMPLE_SIZE);
+        pkt[77] = (plug_headset ? 0x16 : 0x13) | 0 << 6 | 1 << 7; // Speaker: 0x13
         // L Headset Mono: 0x14
         // L Headset R Speaker: 0x15
         // Headset: 0x16
-        pkt[143] = 200;
+        pkt[78] = 200;
         critical_section_enter_blocking(&opus_cs);
-        memcpy(pkt + 144, opus_buf, 200);
+        memcpy(pkt + 79, opus_buf, 200);
         critical_section_exit(&opus_cs);
 
-        bt_write(pkt, sizeof(pkt));
+        bt_write(pkt, sizeof(pkt), true);
         haptic_buf_pos = 0;
     }
 }

--- a/src/audio.h
+++ b/src/audio.h
@@ -5,12 +5,9 @@
 #ifndef DS5_BRIDGE_AUDIO_H
 #define DS5_BRIDGE_AUDIO_H
 
-#include <cstdint>
-
 void audio_init();
 void audio_loop();
 void core1_entry();
 void set_headset(bool state);
-void set_state_data(const uint8_t* data, const uint8_t len);
 
 #endif //DS5_BRIDGE_AUDIO_H

--- a/src/battery_led.cpp
+++ b/src/battery_led.cpp
@@ -38,11 +38,6 @@ void battery_led_note_report(void) {
 }
 
 void battery_led_tick(void) {
-    if (get_config().disable_pico_led) {
-        blinking = false;
-        return;
-    }
-
     const uint64_t now = time_us_64();
     if (last_report_us == 0 || (now - last_report_us) >= REPORT_STALE_US) {
         // No fresh data — bt.cpp owns the LED while disconnected.
@@ -56,6 +51,7 @@ void battery_led_tick(void) {
     const bool low    = (st == POWER_STATE_DISCHARGING) && (pct <= THRESHOLD_LEVEL);
 
     if (low) {
+        // Critical warning: override disable_pico_led so the user always sees it.
         if (!blinking) {
             blinking = true;
             led_state = true;
@@ -70,8 +66,8 @@ void battery_led_tick(void) {
         }
     } else if (blinking) {
         blinking = false;
-        // We were blinking and are still receiving fresh reports => still connected.
-        // Restore the LED to the bt.cpp "connected = solid on" state.
-        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, true);
+        // Battery recovered or now charging — restore steady-state LED per the user
+        // preference flag (LED off when disabled, otherwise the bt.cpp connected = on state).
+        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, !get_config().disable_pico_led);
     }
 }

--- a/src/battery_led.cpp
+++ b/src/battery_led.cpp
@@ -1,0 +1,77 @@
+//
+// Low-battery LED indicator. See battery_led.h.
+//
+
+#include "battery_led.h"
+
+#include <cstdint>
+
+#include "config.h"
+#include "pico/cyw43_arch.h"
+#include "pico/time.h"
+
+extern uint8_t interrupt_in_data[63];
+
+namespace {
+
+constexpr uint64_t REPORT_STALE_US = 2'000'000;  // assume disconnected if no report for 2 s
+constexpr uint64_t BLINK_PERIOD_US =   500'000;  // 1 Hz, 50% duty
+constexpr uint8_t  THRESHOLD_LEVEL = 1;          // PowerPercent <= 1 (i.e. <= 10%)
+constexpr uint8_t  POWER_STATE_DISCHARGING = 0x0;
+
+uint64_t last_report_us = 0;
+uint64_t last_toggle_us = 0;
+bool     blinking       = false;
+bool     led_state      = false;
+
+}  // namespace
+
+void battery_led_init(void) {
+    last_report_us = 0;
+    last_toggle_us = 0;
+    blinking = false;
+    led_state = false;
+}
+
+void battery_led_note_report(void) {
+    last_report_us = time_us_64();
+}
+
+void battery_led_tick(void) {
+    if (get_config().disable_pico_led) {
+        blinking = false;
+        return;
+    }
+
+    const uint64_t now = time_us_64();
+    if (last_report_us == 0 || (now - last_report_us) >= REPORT_STALE_US) {
+        // No fresh data — bt.cpp owns the LED while disconnected.
+        blinking = false;
+        return;
+    }
+
+    const uint8_t b   = interrupt_in_data[52];
+    const uint8_t pct = b & 0x0F;
+    const uint8_t st  = (b >> 4) & 0x0F;
+    const bool low    = (st == POWER_STATE_DISCHARGING) && (pct <= THRESHOLD_LEVEL);
+
+    if (low) {
+        if (!blinking) {
+            blinking = true;
+            led_state = true;
+            last_toggle_us = now;
+            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, true);
+            return;
+        }
+        if ((now - last_toggle_us) >= BLINK_PERIOD_US) {
+            led_state = !led_state;
+            last_toggle_us = now;
+            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_state);
+        }
+    } else if (blinking) {
+        blinking = false;
+        // We were blinking and are still receiving fresh reports => still connected.
+        // Restore the LED to the bt.cpp "connected = solid on" state.
+        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, true);
+    }
+}

--- a/src/battery_led.h
+++ b/src/battery_led.h
@@ -1,0 +1,18 @@
+//
+// Low-battery LED indicator for the Pico onboard LED.
+// Reads PowerPercent / PowerState from interrupt_in_data[52]
+// (DualSense BT 0x31 report, see USBGetStateData in utils.h).
+//
+
+#pragma once
+
+void battery_led_init(void);
+
+// Call once per main-loop iteration. Drives the LED blink while the
+// battery is low and the controller is connected; otherwise no-op.
+void battery_led_tick(void);
+
+// Call from the BT input-report callback whenever a fresh 0x31 report
+// has been copied into interrupt_in_data. Used to detect disconnection
+// via stale-report timeout.
+void battery_led_note_report(void);

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -39,6 +39,7 @@ static bt_data_callback_t bt_data_callback = nullptr;
 static bool check_dse = false;
 unordered_map<uint8_t, vector<uint8_t> > feature_data;
 queue_t send_fifo;
+queue_t priority_send_fifo;
 
 struct send_element {
     uint8_t data[512];
@@ -86,6 +87,7 @@ void bt_l2cap_init() {
 
 int bt_init() {
     queue_init(&send_fifo, sizeof(send_element), 10);
+    queue_init(&priority_send_fifo, sizeof(send_element), 10);
 
     bt_l2cap_init();
 
@@ -475,14 +477,20 @@ static void l2cap_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t 
         case L2CAP_EVENT_CAN_SEND_NOW: {
             // printf("[L2CAP] L2CAP_EVENT_CAN_SEND_NOW\n");
 
-            static send_element send_packet{};
-            if (queue_try_remove(&send_fifo, &send_packet)) {
+            send_element send_packet{};
+            bool get_data = false;
+            if (!queue_is_empty(&priority_send_fifo)) {
+                get_data = queue_try_remove(&priority_send_fifo, &send_packet);
+            }else {
+                get_data = queue_try_remove(&send_fifo, &send_packet);
+            }
+            if (get_data) {
                 const uint8_t status = l2cap_send(hid_interrupt_cid, send_packet.data, send_packet.len);
                 if (status != 0) {
                     printf("[L2CAP] L2CAP Send Error, Status: 0x%02X\n", status);
                 }
             }
-            if (!queue_is_empty(&send_fifo)) {
+            if (!queue_is_empty(&priority_send_fifo) || !queue_is_empty(&send_fifo)) {
                 l2cap_request_can_send_now_event(hid_interrupt_cid);
             }
             break;
@@ -490,7 +498,7 @@ static void l2cap_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t 
     }
 }
 
-void bt_write(uint8_t *data, uint16_t len) {
+void bt_write(const uint8_t *data, const uint16_t len, const bool priority) {
     if (hid_interrupt_cid == 0) return;
     static send_element packet{};
     memset(packet.data, 0, 512);
@@ -499,11 +507,18 @@ void bt_write(uint8_t *data, uint16_t len) {
     memcpy(packet.data + 1, data, len);
     fill_output_report_checksum(packet.data + 1, len);
 
-    if (!queue_try_add(&send_fifo, &packet)) {
-        printf("[L2CAP bt_write] Error: Failed to add packet to send FIFO\n");
-        return;
+    if (priority) {
+        if (!queue_try_add(&priority_send_fifo, &packet)) {
+            printf("[L2CAP bt_write] Error: Failed to add packet to send FIFO\n");
+            return;
+        }
+    }else {
+        if (!queue_try_add(&send_fifo, &packet)) {
+            printf("[L2CAP bt_write] Error: Failed to add packet to send FIFO\n");
+            return;
+        }
     }
-    if (queue_get_level(&send_fifo) == 1) {
+    if (queue_get_level(&send_fifo) + queue_get_level(&priority_send_fifo) == 1) {
         l2cap_request_can_send_now_event(hid_interrupt_cid);
     }
 }

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -162,12 +162,9 @@ static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
             break;
         }
 
-        case GAP_EVENT_INQUIRY_COMPLETE: {
-            printf("[HCI] GAP Inquiry complete.\n");
-            break;
-        }
+        case GAP_EVENT_INQUIRY_COMPLETE:
         case HCI_EVENT_INQUIRY_COMPLETE: {
-            printf("[HCI] HCI Inquiry complete.\n");
+            printf("[HCI] Inquiry complete.\n");
             if (device_found) {
                 printf("[HCI] Connecting to %s...\n", bd_addr_to_str(current_device_addr));
                 new_pair = true;
@@ -175,10 +172,12 @@ static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
                              hci_usable_acl_packet_types(), 0, 0, 0, 1);
                 break;
             }
-            printf("[HCI] Restart inquiry\n");
-            gap_inquiry_start(30);
-            gap_connectable_control(1);
-            gap_discoverable_control(1);
+            if (event_type == HCI_EVENT_INQUIRY_COMPLETE) {
+                printf("[HCI] Restart inquiry\n");
+                gap_inquiry_start(30);
+                gap_connectable_control(1);
+                gap_discoverable_control(1);
+            }
             break;
         }
         case HCI_EVENT_COMMAND_STATUS: {

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -509,7 +509,7 @@ void bt_write(const uint8_t *data, const uint16_t len, const bool priority) {
 
     if (priority) {
         if (!queue_try_add(&priority_send_fifo, &packet)) {
-            printf("[L2CAP bt_write] Error: Failed to add packet to send FIFO\n");
+            printf("[L2CAP bt_write] Error: Failed to add packet to priority send FIFO\n");
             return;
         }
     }else {

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -164,13 +164,18 @@ static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
 
         case GAP_EVENT_INQUIRY_COMPLETE:
         case HCI_EVENT_INQUIRY_COMPLETE: {
-            printf("[HCI] Inquiry complete\n");
+            printf("[HCI] Inquiry complete.\n");
             if (device_found) {
                 printf("[HCI] Connecting to %s...\n", bd_addr_to_str(current_device_addr));
                 new_pair = true;
                 hci_send_cmd(&hci_create_connection, current_device_addr,
                              hci_usable_acl_packet_types(), 0, 0, 0, 1);
+                break;
             }
+            printf("[HCI] Restart inquiry\n");
+            gap_inquiry_start(30);
+            gap_connectable_control(1);
+            gap_discoverable_control(1);
             break;
         }
         case HCI_EVENT_COMMAND_STATUS: {

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -162,9 +162,12 @@ static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
             break;
         }
 
-        case GAP_EVENT_INQUIRY_COMPLETE:
+        case GAP_EVENT_INQUIRY_COMPLETE: {
+            printf("[HCI] GAP Inquiry complete.\n");
+            break;
+        }
         case HCI_EVENT_INQUIRY_COMPLETE: {
-            printf("[HCI] Inquiry complete.\n");
+            printf("[HCI] HCI Inquiry complete.\n");
             if (device_found) {
                 printf("[HCI] Connecting to %s...\n", bd_addr_to_str(current_device_addr));
                 new_pair = true;

--- a/src/bt.h
+++ b/src/bt.h
@@ -19,7 +19,7 @@ int bt_init();
 void bt_register_data_callback(bt_data_callback_t callback);
 void bt_send_packet(uint8_t *data, uint16_t len);
 void bt_send_control(uint8_t *data, uint16_t len);
-void bt_write(uint8_t* data,uint16_t len);
+void bt_write(const uint8_t *data, uint16_t len, bool priority = false);
 std::vector<uint8_t> get_feature_data(uint8_t reportId,uint16_t len);
 void init_feature();
 void set_feature_data(uint8_t reportId, uint8_t* data,uint16_t len);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,6 @@
 
 int reportSeqCounter = 0;
 uint8_t packetCounter = 0;
-bool spk_active = false;
 
 uint8_t interrupt_in_data[63] = {
     0x7f, 0x7d, 0x7f, 0x7e, 0x00, 0x00, 0xa7,
@@ -157,7 +156,6 @@ bool tud_audio_set_itf_cb(uint8_t rhport, tusb_control_request_t const *p_reques
 
     if (itf == 1) {
         printf("[AUDIO] Set interface Speaker to alternate setting %d\n", alt);
-        spk_active = alt;
     }
 
     return true;
@@ -189,10 +187,6 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
     if (report_id == 0) {
         switch (buffer[0]) {
             case 0x02: {
-                set_state_data(buffer + 1, bufsize - 1);
-                if (spk_active) {
-                    break;
-                }
                 uint8_t outputData[78];
                 outputData[0] = 0x31;
                 outputData[1] = reportSeqCounter << 4;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,23 +85,27 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
             set_headset(data[56] & 1);
         }
 
+        // Wake-on-PS must observe every BT input report regardless of polling
+        // mode: the wake feature has its own state to maintain (button-byte
+        // diff for edge detection) and short-circuiting it on non-2 polling
+        // modes silently breaks wake while the host is suspended.
+        wake_on_bt_input(data + 3, len - 3);
+
         if (get_config().polling_rate_mode != 2) {
             memcpy(interrupt_in_data, data + 3, 63);
             return;
         }
 
         // We add the critical section here to avoid any race conditions when writing to the interrupt_in_data buffer,
-        // which is shared between the main loop and this callback. 
-        // The critical section ensures that only one thread can access the buffer at a time, 
-        // preventing data corruption and ensuring thread safety.   
+        // which is shared between the main loop and this callback.
+        // The critical section ensures that only one thread can access the buffer at a time,
+        // preventing data corruption and ensuring thread safety.
         // We also set the report_dirty flag to true to indicate that new data is available
         //  and needs to be sent in the next interrupt report.
         critical_section_enter_blocking(&report_cs);
         memcpy(interrupt_in_data, data + 3, 63);
         report_dirty = true;
         critical_section_exit(&report_cs);
-
-        wake_on_bt_input(data + 3, len - 3);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,9 @@
 #endif
 #include "config.h"
 #include "cmd.h"
+#if ENABLE_BATT_LED
+#include "battery_led.h"
+#endif
 
 // Pico SDK speciifically for waiting on conditions
 #include "pico/critical_section.h"
@@ -86,6 +89,9 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
 
         if (get_config().polling_rate_mode != 2) {
             memcpy(interrupt_in_data, data + 3, 63);
+#if ENABLE_BATT_LED
+            battery_led_note_report();
+#endif
             return;
         }
 
@@ -99,6 +105,9 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
         memcpy(interrupt_in_data, data + 3, 63);
         report_dirty = true;
         critical_section_exit(&report_cs);
+#if ENABLE_BATT_LED
+        battery_led_note_report();
+#endif
     }
 }
 
@@ -210,6 +219,10 @@ int main() {
     }
     cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
 
+#if ENABLE_BATT_LED
+    battery_led_init();
+#endif
+
 #if !ENABLE_SERIAL
     if (watchdog_caused_reboot()) {
         printf("Rebooted by Watchdog!\n");
@@ -249,5 +262,8 @@ int main() {
         tud_task();
         audio_loop();
         interrupt_loop();
+#if ENABLE_BATT_LED
+        battery_led_tick();
+#endif
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,6 +197,7 @@ int main() {
     };
     tusb_init(BOARD_TUD_RHPORT, &dev_init);
 #if !ENABLE_SERIAL
+    sleep_ms(150);
     tud_disconnect();
 #endif
     board_init_after_tusb();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "utils.h"
 #include "resample.h"
 #include "audio.h"
+#include "wake.h"
 #include "hardware/clocks.h"
 #include "hardware/vreg.h"
 #include "hardware/watchdog.h"
@@ -99,6 +100,8 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
         memcpy(interrupt_in_data, data + 3, 63);
         report_dirty = true;
         critical_section_exit(&report_cs);
+
+        wake_on_bt_input(data + 3, len - 3);
     }
 }
 
@@ -107,6 +110,15 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
 // Return zero will cause the stack to STALL request
 uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t *buffer,
                                uint16_t reqlen) {
+#ifdef ENABLE_WAKE_HID
+    if (itf == 1) {
+        if (reqlen >= 8) {
+            memset(buffer, 0, 8);
+            return 8;
+        }
+        return 0;
+    }
+#endif
     (void) itf;
     (void) report_id;
     (void) report_type;
@@ -142,6 +154,12 @@ bool tud_audio_set_itf_cb(uint8_t rhport, tusb_control_request_t const *p_reques
 // received data on OUT endpoint ( Report ID = 0, Type = 0 )
 void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer,
                            uint16_t bufsize) {
+#ifdef ENABLE_WAKE_HID
+    if (itf == 1) {
+        // Drop keyboard SET_REPORT (host LED state).
+        return;
+    }
+#endif
     (void) itf;
     (void) report_id;
     (void) report_type;
@@ -229,6 +247,7 @@ int main() {
 
     // Initialize the critical section for the report buffer
     critical_section_init(&report_cs);
+    wake_init();
 
     config_load();
 
@@ -247,6 +266,7 @@ int main() {
 #endif
         cyw43_arch_poll();
         tud_task();
+        wake_task();
         audio_loop();
         interrupt_loop();
     }

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -104,7 +104,11 @@
 #define CFG_TUD_CDC               ENABLE_SERIAL
 #define CFG_TUD_MSC               0
 #define CFG_TUD_MIDI              0
+#ifdef ENABLE_WAKE_HID
+#define CFG_TUD_VENDOR            1 // routes MS OS 2.0 vendor request to tud_vendor_control_xfer_cb
+#else
 #define CFG_TUD_VENDOR            0
+#endif
 
 // HID buffer size Should be sufficient to hold ID (if any) + Data
 #define CFG_TUD_HID_EP_BUFSIZE    64

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -96,7 +96,11 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_AUDIO             1
+#ifdef ENABLE_WAKE_HID
+#define CFG_TUD_HID               2
+#else
 #define CFG_TUD_HID               1
+#endif
 #define CFG_TUD_CDC               ENABLE_SERIAL
 #define CFG_TUD_MSC               0
 #define CFG_TUD_MIDI              0

--- a/src/usb_descriptors.cpp
+++ b/src/usb_descriptors.cpp
@@ -91,7 +91,11 @@ tusb_desc_device_t desc_device =
 {
     .bLength = sizeof(tusb_desc_device_t),
     .bDescriptorType = TUSB_DESC_DEVICE,
+#ifdef ENABLE_WAKE_HID
+    .bcdUSB = 0x0210, // USB 2.1 -- required so the host requests BOS (carries our MS OS 2.0 descriptor)
+#else
     .bcdUSB = 0x0200,
+#endif
 
     // Use Interface Association Descriptor (IAD) for Audio
     // As required by USB Specs IAD's subclass must be common class (2) and protocol must be IAD (1)
@@ -942,3 +946,96 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
 
     return _desc_str;
 }
+
+#ifdef ENABLE_WAKE_HID
+//--------------------------------------------------------------------+
+// Microsoft OS 2.0 descriptors (carried via BOS).
+//
+// Why this is here: the dongle is a composite device with USB Audio Class
+// interfaces. By default Windows audio engine policy keeps USB audio devices
+// at D0 even during system S3, blocking selective-suspend for the whole
+// composite. Without selective-suspend the device never enters USB suspend,
+// so tud_remote_wakeup() never works -- breaking wake-on-PS.
+//
+// MS OS 2.0 lets us tell Windows "yes, please selective-suspend this audio
+// function": we set the registry property "SelectiveSuspendEnabled" = 1 on
+// the audio function (interface 0). This causes Windows to write
+//   HKLM\SYSTEM\CurrentControlSet\Enum\USB\<VID&PID>\<instance>
+//        \Device Parameters\SelectiveSuspendEnabled = 1
+// at enumeration time, opting our audio function in to selective suspend
+// without breaking haptics.
+//
+// Reference: "Microsoft OS 2.0 Descriptors Specification".
+//--------------------------------------------------------------------+
+
+#define MS_OS_20_VENDOR_CODE 0x01
+
+// Total length of the MS OS 2.0 descriptor set:
+//   Set Header (10) + Config Subset (8) + Function Subset (8) +
+//   Registry Property Feature (10 fixed + 48 name + 4 data = 62) = 88 bytes.
+// Used in BOS platform capability descriptor; verified by static_assert below.
+#define MS_OS_20_DESC_LEN    88
+
+#define BOS_TOTAL_LEN        (TUD_BOS_DESC_LEN + TUD_BOS_MICROSOFT_OS_DESC_LEN)
+
+uint8_t const desc_bos[] = {
+    // BOS header
+    TUD_BOS_DESCRIPTOR(BOS_TOTAL_LEN, 1),
+    // Platform capability: MS OS 2.0
+    TUD_BOS_MS_OS_20_DESCRIPTOR(MS_OS_20_DESC_LEN, MS_OS_20_VENDOR_CODE)
+};
+
+uint8_t const *tud_descriptor_bos_cb(void) {
+    return desc_bos;
+}
+
+uint8_t const desc_ms_os_20[] = {
+    // --- Set Header (10 bytes) ---
+    U16_TO_U8S_LE(0x000A),                                    // wLength
+    U16_TO_U8S_LE(MS_OS_20_SET_HEADER_DESCRIPTOR),            // wDescriptorType
+    U32_TO_U8S_LE(0x06030000),                                // dwWindowsVersion = Win 8.1+
+    U16_TO_U8S_LE(MS_OS_20_DESC_LEN),                         // wTotalLength
+
+    // --- Configuration Subset (8 bytes) ---
+    U16_TO_U8S_LE(0x0008),                                    // wLength
+    U16_TO_U8S_LE(MS_OS_20_SUBSET_HEADER_CONFIGURATION),      // wDescriptorType
+    0x00,                                                     // bConfigurationValue (config index, 0)
+    0x00,                                                     // bReserved
+    U16_TO_U8S_LE(MS_OS_20_DESC_LEN - 0x0A),                  // wTotalLength of this subset
+
+    // --- Function Subset for the Audio function (8 bytes) ---
+    // Audio Control is interface 0; AudioStreaming OUT/IN are 1/2 -- this
+    // subset covers all three because they belong to the same function.
+    U16_TO_U8S_LE(0x0008),                                    // wLength
+    U16_TO_U8S_LE(MS_OS_20_SUBSET_HEADER_FUNCTION),           // wDescriptorType
+    0x00,                                                     // bFirstInterface (audio control)
+    0x00,                                                     // bReserved
+    U16_TO_U8S_LE(MS_OS_20_DESC_LEN - 0x0A - 0x08),           // wSubsetLength
+
+    // --- Feature: Registry Property "SelectiveSuspendEnabled" = 1 (62 bytes) ---
+    U16_TO_U8S_LE(0x003E),                                    // wLength = 62
+    U16_TO_U8S_LE(MS_OS_20_FEATURE_REG_PROPERTY),             // wDescriptorType
+    U16_TO_U8S_LE(0x0004),                                    // wPropertyDataType = REG_DWORD_LITTLE_ENDIAN
+    U16_TO_U8S_LE(48),                                        // wPropertyNameLength = 48 bytes (24 UTF-16 chars)
+    // PropertyName "SelectiveSuspendEnabled\0" UTF-16LE (48 bytes)
+    'S',0, 'e',0, 'l',0, 'e',0, 'c',0, 't',0, 'i',0, 'v',0,
+    'e',0, 'S',0, 'u',0, 's',0, 'p',0, 'e',0, 'n',0, 'd',0,
+    'E',0, 'n',0, 'a',0, 'b',0, 'l',0, 'e',0, 'd',0,  0,0,
+    U16_TO_U8S_LE(0x0004),                                    // wPropertyDataLength = 4 bytes
+    U32_TO_U8S_LE(0x00000001),                                // PropertyData = 1 (enabled)
+};
+TU_VERIFY_STATIC(sizeof(desc_ms_os_20) == MS_OS_20_DESC_LEN, "MS OS 2.0 descriptor length mismatch");
+
+// Vendor-class control transfer hook. Windows reads BOS, sees the MS OS 2.0
+// platform capability, then issues this vendor request to fetch the
+// descriptor set itself.
+bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const *request) {
+    if (stage != CONTROL_STAGE_SETUP) return true;
+    if (request->bmRequestType_bit.type != TUSB_REQ_TYPE_VENDOR) return false;
+    if (request->bRequest == MS_OS_20_VENDOR_CODE && request->wIndex == 7) {
+        // wIndex == 7 -> MS_OS_20_DESCRIPTOR_INDEX
+        return tud_control_xfer(rhport, request, (void *)(uintptr_t)desc_ms_os_20, sizeof(desc_ms_os_20));
+    }
+    return false;
+}
+#endif // ENABLE_WAKE_HID

--- a/src/usb_descriptors.cpp
+++ b/src/usb_descriptors.cpp
@@ -47,6 +47,9 @@ enum {
     ITF_NUM_CDC,
     ITF_NUM_CDC_DATA,
 #endif
+#ifdef ENABLE_WAKE_HID
+    ITF_NUM_HID_KBD,
+#endif
     ITF_NUM_TOTAL,
 
     CONFIG_DESC_LEN_AUDIO_IAD =
@@ -56,7 +59,15 @@ enum {
         0,
 #endif
     CONFIG_DESC_LEN_BASE = 0x00E3 + CONFIG_DESC_LEN_AUDIO_IAD,
-    CONFIG_DESC_LEN_TOTAL = CONFIG_DESC_LEN_BASE
+    // Keyboard interface adds 25 bytes:
+    //   9 (interface) + 9 (HID class) + 7 (EP IN) = 25
+    CONFIG_DESC_LEN_WAKE_KBD =
+#ifdef ENABLE_WAKE_HID
+        25,
+#else
+        0,
+#endif
+    CONFIG_DESC_LEN_TOTAL = CONFIG_DESC_LEN_BASE + CONFIG_DESC_LEN_WAKE_KBD
 #if ENABLE_SERIAL
         + TUD_CDC_DESC_LEN
 #endif
@@ -125,7 +136,11 @@ uint8_t descriptor_configuration[] = {
     ITF_NUM_TOTAL, // bNumInterfaces
     0x01, // bConfigurationValue: 1
     0x00, // iConfiguration: 0
+#ifdef ENABLE_WAKE_HID
+    0xE0, // bmAttributes: SELF-POWERED + REMOTE-WAKEUP
+#else
     0xC0, // bmAttributes: SELF-POWERED, NO REMOTE-WAKEUP
+#endif
     0xFA, // bMaxPower: 500mA (250 * 2mA)
 
 #if ENABLE_SERIAL
@@ -384,6 +399,37 @@ uint8_t descriptor_configuration[] = {
 #if ENABLE_SERIAL
     // --- CDC ACM (USB Serial) ---
     TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, STRID_CDC, 0x85, 0x08, 0x06, 0x86, 0x40),
+#endif
+#ifdef ENABLE_WAKE_HID
+    // --- INTERFACE DESCRIPTOR (HID Boot Keyboard, wake key only) ---
+    // EP IN 0x87 (chosen to avoid collision with CDC notification EP 0x85
+    // when ENABLE_SERIAL is also defined).
+    0x09, // bLength
+    0x04, // bDescriptorType (INTERFACE)
+    ITF_NUM_HID_KBD, // bInterfaceNumber
+    0x00, // bAlternateSetting: 0
+    0x01, // bNumEndpoints: 1 (IN only)
+    0x03, // bInterfaceClass: HID
+    0x01, // bInterfaceSubClass: Boot
+    0x01, // bInterfaceProtocol: Keyboard
+    0x00, // iInterface
+
+    // HID Descriptor (keyboard)
+    0x09, // bLength
+    0x21, // bDescriptorType (HID)
+    0x11, 0x01, // bcdHID: 1.11
+    0x00, // bCountryCode
+    0x01, // bNumDescriptors
+    0x22, // bDescriptorType: Report
+    0x2D, 0x00, // wDescriptorLength: 45 (sizeof desc_hid_report_kbd)
+
+    // Endpoint Descriptor (HID IN: EP7)
+    0x07, // bLength
+    0x05, // bDescriptorType (ENDPOINT)
+    0x87, // bEndpointAddress: IN EP7
+    0x03, // bmAttributes: Interrupt
+    0x08, 0x00, // wMaxPacketSize: 8 (boot keyboard report)
+    0x0A, // bInterval: 10ms
 #endif
 };
 
@@ -785,10 +831,45 @@ uint8_t const desc_hid_report_dse[] = {
     // 421 bytes
 };
 
+#ifdef ENABLE_WAKE_HID
+// 41-byte boot-keyboard report descriptor (modifier byte + reserved + 6 keycodes,
+// no Report ID -- boot protocol forbids one and avoids collision with the gamepad's Report ID 1).
+uint8_t const desc_hid_report_kbd[] = {
+    0x05, 0x01,       // Usage Page (Generic Desktop)
+    0x09, 0x06,       // Usage (Keyboard)
+    0xA1, 0x01,       // Collection (Application)
+    0x05, 0x07,       //   Usage Page (Keyboard/Keypad)
+    0x19, 0xE0,       //   Usage Minimum (Left Control)
+    0x29, 0xE7,       //   Usage Maximum (Right GUI)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x25, 0x01,       //   Logical Maximum (1)
+    0x75, 0x01,       //   Report Size (1)
+    0x95, 0x08,       //   Report Count (8)
+    0x81, 0x02,       //   Input (Data,Var,Abs) -- modifier byte
+    0x95, 0x01,       //   Report Count (1)
+    0x75, 0x08,       //   Report Size (8)
+    0x81, 0x01,       //   Input (Const) -- reserved byte
+    0x95, 0x06,       //   Report Count (6)
+    0x75, 0x08,       //   Report Size (8)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x25, 0x65,       //   Logical Maximum (101)
+    0x05, 0x07,       //   Usage Page (Keyboard/Keypad)
+    0x19, 0x00,       //   Usage Minimum (0)
+    0x29, 0x65,       //   Usage Maximum (101)
+    0x81, 0x00,       //   Input (Data,Array) -- 6 keycodes
+    0xC0              // End Collection
+};
+_Static_assert(sizeof(desc_hid_report_kbd) == 45, "keyboard report descriptor length must match wDescriptorLength in config descriptor");
+#endif
+
 // Invoked when received GET HID REPORT DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
 uint8_t const *tud_hid_descriptor_report_cb(uint8_t itf) {
+#ifdef ENABLE_WAKE_HID
+    // HID instance 1 is the wake-only boot keyboard added by ENABLE_WAKE_HID.
+    if (itf == 1) return desc_hid_report_kbd;
+#endif
     (void) itf;
     if (ds_mode()) {
         return desc_hid_report_ds;

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -20,6 +20,23 @@
 #define WAKE_KEY_UP_SETTLE_US 10000
 #define WAKE_REQUEST_TIMEOUT_US 5000000
 
+#ifdef WAKE_DEBUG
+#  define WAKE_DBG(fmt, ...) printf("[wake] " fmt "\n", ##__VA_ARGS__)
+static const char *wake_state_name(int s) {
+    switch (s) {
+    case 0: return "IDLE";
+    case 1: return "PENDING_PRESS";
+    case 2: return "REQUESTED";
+    case 3: return "KEY_DOWN";
+    case 4: return "KEY_UP_SENT";
+    case 5: return "DONE";
+    default: return "?";
+    }
+}
+#else
+#  define WAKE_DBG(fmt, ...) ((void)0)
+#endif
+
 typedef enum {
     WAKE_IDLE,
     WAKE_PENDING_PRESS,
@@ -50,16 +67,19 @@ void wake_init(void) {
 }
 
 extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
-    (void)remote_wakeup_en;
+    WAKE_DBG("tud_suspend_cb remote_wakeup_en=%d prev_state=%s",
+             (int)remote_wakeup_en, wake_state_name(state));
     host_suspended = true;
     if (state == WAKE_IDLE || state == WAKE_DONE) {
         state = WAKE_PENDING_PRESS;
         state_entered_us = time_us_64();
         prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
+        WAKE_DBG("-> PENDING_PRESS");
     }
 }
 
 extern "C" void tud_resume_cb(void) {
+    WAKE_DBG("tud_resume_cb state=%s", wake_state_name(state));
     host_suspended = false;
     host_resumed_event = true;
 }
@@ -97,12 +117,24 @@ void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
     critical_section_exit(&wake_cs);
 
     if (changed && armable) {
-        if (tud_remote_wakeup()) {
+        const bool ok = tud_remote_wakeup();
+        if (ok) {
             critical_section_enter_blocking(&wake_cs);
             state = WAKE_REQUESTED;
             state_entered_us = time_us_64();
             critical_section_exit(&wake_cs);
+            WAKE_DBG("button event -> REQUESTED, tud_remote_wakeup()=1");
         }
+#ifdef WAKE_DEBUG
+        else {
+            static uint64_t last_log = 0;
+            const uint64_t now = time_us_64();
+            if (now - last_log > 5000000) {
+                WAKE_DBG("button event, tud_remote_wakeup()=0 (host awake or wake disabled) -- 5s heartbeat");
+                last_log = now;
+            }
+        }
+#endif
     }
 }
 
@@ -131,14 +163,26 @@ void wake_task(void) {
             if (host_resumed_event || !host_suspended) {
                 host_resumed_event = false;
                 if (now - entered < WAKE_SETTLE_US) return;
-                if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) return;
+                if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) {
+#ifdef WAKE_DEBUG
+                    static uint64_t last_log = 0;
+                    if (now - last_log > 1000000) {
+                        WAKE_DBG("REQUESTED waiting: hid_n_ready=0 (heartbeat 1Hz)");
+                        last_log = now;
+                    }
+#endif
+                    return;
+                }
                 uint8_t rpt[8] = { 0, 0, WAKE_KEYCODE_F15, 0, 0, 0, 0, 0 };
-                if (tud_hid_n_report(WAKE_KBD_INSTANCE, 0, rpt, sizeof(rpt))) {
+                const bool sent = tud_hid_n_report(WAKE_KBD_INSTANCE, 0, rpt, sizeof(rpt));
+                WAKE_DBG("REQUESTED: sent keydown 0x%02X -> %d", WAKE_KEYCODE_F15, (int)sent);
+                if (sent) {
                     critical_section_enter_blocking(&wake_cs);
                     enter_state(WAKE_KEY_DOWN);
                     critical_section_exit(&wake_cs);
                 }
             } else if (now - entered > WAKE_REQUEST_TIMEOUT_US) {
+                WAKE_DBG("REQUESTED timeout 5s -> DONE (host never resumed)");
                 critical_section_enter_blocking(&wake_cs);
                 enter_state(WAKE_DONE);
                 critical_section_exit(&wake_cs);
@@ -148,9 +192,20 @@ void wake_task(void) {
 
         case WAKE_KEY_DOWN: {
             if (now - entered < WAKE_KEY_HOLD_US) return;
-            if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) return;
+            if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) {
+#ifdef WAKE_DEBUG
+                static uint64_t last_log = 0;
+                if (now - last_log > 1000000) {
+                    WAKE_DBG("KEY_DOWN waiting: hid_n_ready=0 (heartbeat 1Hz)");
+                    last_log = now;
+                }
+#endif
+                return;
+            }
             uint8_t up[8] = { 0 };
-            if (tud_hid_n_report(WAKE_KBD_INSTANCE, 0, up, sizeof(up))) {
+            const bool sent = tud_hid_n_report(WAKE_KBD_INSTANCE, 0, up, sizeof(up));
+            WAKE_DBG("KEY_DOWN: sent keyup -> %d", (int)sent);
+            if (sent) {
                 critical_section_enter_blocking(&wake_cs);
                 enter_state(WAKE_KEY_UP_SENT);
                 critical_section_exit(&wake_cs);
@@ -160,6 +215,7 @@ void wake_task(void) {
 
         case WAKE_KEY_UP_SENT: {
             if (now - entered < WAKE_KEY_UP_SETTLE_US) return;
+            WAKE_DBG("KEY_UP_SENT settle done -> DONE");
             critical_section_enter_blocking(&wake_cs);
             enter_state(WAKE_DONE);
             critical_section_exit(&wake_cs);

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -1,0 +1,146 @@
+//
+// Created by awalol on 2026/4/30.
+//
+
+#include "wake.h"
+
+#ifdef ENABLE_WAKE_HID
+
+#include <cstdio>
+#include <cstring>
+
+#include "tusb.h"
+#include "pico/sync.h"
+#include "pico/time.h"
+
+#define WAKE_KBD_INSTANCE     1
+#define WAKE_KEYCODE_F15      0x68
+#define WAKE_SETTLE_US        20000
+#define WAKE_KEY_HOLD_US      30000
+#define WAKE_KEY_UP_SETTLE_US 10000
+#define WAKE_REQUEST_TIMEOUT_US 5000000
+
+typedef enum {
+    WAKE_IDLE,
+    WAKE_PENDING_PRESS,
+    WAKE_REQUESTED,
+    WAKE_KEY_DOWN,
+    WAKE_KEY_UP_SENT,
+    WAKE_DONE,
+} wake_state_t;
+
+static critical_section_t wake_cs;
+static volatile bool host_suspended = false;
+static volatile bool host_resumed_event = false;
+static wake_state_t state = WAKE_IDLE;
+static uint64_t state_entered_us = 0;
+static uint8_t prev_ps_bit = 1;
+
+static void enter_state(wake_state_t s) {
+    state = s;
+    state_entered_us = time_us_64();
+}
+
+void wake_init(void) {
+    critical_section_init(&wake_cs);
+}
+
+extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
+    (void)remote_wakeup_en;
+    host_suspended = true;
+    if (state == WAKE_IDLE || state == WAKE_DONE) {
+        state = WAKE_PENDING_PRESS;
+        state_entered_us = time_us_64();
+        prev_ps_bit = 1;
+    }
+}
+
+extern "C" void tud_resume_cb(void) {
+    host_suspended = false;
+    host_resumed_event = true;
+}
+
+void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
+    if (len < 9) return;
+    const uint8_t ps_now = hid_input[8] & 0x01;
+
+    critical_section_enter_blocking(&wake_cs);
+    const bool edge = (prev_ps_bit == 0 && ps_now == 1);
+    prev_ps_bit = ps_now;
+    const bool act = edge && state == WAKE_PENDING_PRESS;
+    if (act) {
+        state = WAKE_REQUESTED;
+        state_entered_us = time_us_64();
+    }
+    critical_section_exit(&wake_cs);
+
+    if (act) {
+        // Safe no-op if the host did not enable remote wakeup. We still proceed
+        // through the FSM and try to send the key once the host resumes.
+        tud_remote_wakeup();
+    }
+}
+
+void wake_on_bt_disconnect(void) {
+    critical_section_enter_blocking(&wake_cs);
+    state = WAKE_IDLE;
+    prev_ps_bit = 1;
+    critical_section_exit(&wake_cs);
+}
+
+void wake_task(void) {
+    const uint64_t now = time_us_64();
+
+    critical_section_enter_blocking(&wake_cs);
+    const wake_state_t s = state;
+    const uint64_t entered = state_entered_us;
+    critical_section_exit(&wake_cs);
+
+    switch (s) {
+        case WAKE_IDLE:
+        case WAKE_PENDING_PRESS:
+        case WAKE_DONE:
+            return;
+
+        case WAKE_REQUESTED: {
+            if (host_resumed_event || !host_suspended) {
+                host_resumed_event = false;
+                if (now - entered < WAKE_SETTLE_US) return;
+                if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) return;
+                uint8_t rpt[8] = { 0, 0, WAKE_KEYCODE_F15, 0, 0, 0, 0, 0 };
+                if (tud_hid_n_report(WAKE_KBD_INSTANCE, 0, rpt, sizeof(rpt))) {
+                    critical_section_enter_blocking(&wake_cs);
+                    enter_state(WAKE_KEY_DOWN);
+                    critical_section_exit(&wake_cs);
+                }
+            } else if (now - entered > WAKE_REQUEST_TIMEOUT_US) {
+                critical_section_enter_blocking(&wake_cs);
+                enter_state(WAKE_DONE);
+                critical_section_exit(&wake_cs);
+            }
+            return;
+        }
+
+        case WAKE_KEY_DOWN: {
+            if (now - entered < WAKE_KEY_HOLD_US) return;
+            if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) return;
+            uint8_t up[8] = { 0 };
+            if (tud_hid_n_report(WAKE_KBD_INSTANCE, 0, up, sizeof(up))) {
+                critical_section_enter_blocking(&wake_cs);
+                enter_state(WAKE_KEY_UP_SENT);
+                critical_section_exit(&wake_cs);
+            }
+            return;
+        }
+
+        case WAKE_KEY_UP_SENT: {
+            if (now - entered < WAKE_KEY_UP_SETTLE_US) return;
+            critical_section_enter_blocking(&wake_cs);
+            enter_state(WAKE_DONE);
+            critical_section_exit(&wake_cs);
+            return;
+        }
+    }
+}
+
+#endif // ENABLE_WAKE_HID

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -61,8 +61,14 @@ extern "C" void tud_resume_cb(void) {
 }
 
 void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
-    if (len < 9) return;
-    const uint8_t ps_now = hid_input[8] & 0x01;
+    if (len < 10) return;
+    // DualSense BT 0x31 input report layout (after main.cpp's `data + 3` skip):
+    //   byte 7 low nibble: D-pad direction (0x08 idle); high nibble: face buttons
+    //   byte 8: L1, R1, L2 click, R2 click, share, options, L3, R3
+    //   byte 9: PS (bit 0), touchpad-click (bit 1), mute (bit 2)
+    // The PS bit is at byte 9, not byte 8 (which is L1). Verified by capturing
+    // per-button report deltas with a diagnostic firmware.
+    const uint8_t ps_now = hid_input[9] & 0x01;
 
     critical_section_enter_blocking(&wake_cs);
     const bool edge = (prev_ps_bit == 0 && ps_now == 1);

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -34,7 +34,11 @@ static volatile bool host_suspended = false;
 static volatile bool host_resumed_event = false;
 static wake_state_t state = WAKE_IDLE;
 static uint64_t state_entered_us = 0;
-static uint8_t prev_ps_bit = 1;
+// Last-seen DualSense button bytes. Idle defaults: byte 7 = 0x08 (D-pad
+// released), bytes 8 / 9 = 0 (no shoulders, no PS / touchpad / mute).
+static uint8_t prev_b7 = 0x08;
+static uint8_t prev_b8 = 0x00;
+static uint8_t prev_b9 = 0x00;
 
 static void enter_state(wake_state_t s) {
     state = s;
@@ -51,7 +55,7 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
     if (state == WAKE_IDLE || state == WAKE_DONE) {
         state = WAKE_PENDING_PRESS;
         state_entered_us = time_us_64();
-        prev_ps_bit = 1;
+        prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
     }
 }
 
@@ -66,31 +70,46 @@ void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
     //   byte 7 low nibble: D-pad direction (0x08 idle); high nibble: face buttons
     //   byte 8: L1, R1, L2 click, R2 click, share, options, L3, R3
     //   byte 9: PS (bit 0), touchpad-click (bit 1), mute (bit 2)
-    // The PS bit is at byte 9, not byte 8 (which is L1). Verified by capturing
-    // per-button report deltas with a diagnostic firmware.
-    const uint8_t ps_now = hid_input[9] & 0x01;
+    //
+    // We trigger on ANY change in those three button bytes, not strictly on
+    // the PS bit. Reasons:
+    //   1. The DualSense's BT radio enters a low-power sniff mode after a
+    //      period of inactivity. The PS button alone often does not wake
+    //      the radio out of sniff -- shoulder buttons reliably do. So the
+    //      first BT report after S3 is most likely whichever button the
+    //      user happened to press to wake the radio. PS itself counts as
+    //      "any button" too, so the single-press UX still works.
+    //   2. We additionally call tud_remote_wakeup() speculatively even from
+    //      WAKE_IDLE / WAKE_DONE state. TinyUSB returns true only when the
+    //      host actually USB-suspended the bus; otherwise it's a no-op. This
+    //      protects against the case where tud_suspend_cb didn't fire (e.g.
+    //      a hub between the host and the dongle masking the suspend signal
+    //      from downstream). On success the FSM transitions to REQUESTED and
+    //      proceeds with the keystroke as normal.
+    const uint8_t b7 = hid_input[7];
+    const uint8_t b8 = hid_input[8];
+    const uint8_t b9 = hid_input[9];
 
     critical_section_enter_blocking(&wake_cs);
-    const bool edge = (prev_ps_bit == 0 && ps_now == 1);
-    prev_ps_bit = ps_now;
-    const bool act = edge && state == WAKE_PENDING_PRESS;
-    if (act) {
-        state = WAKE_REQUESTED;
-        state_entered_us = time_us_64();
-    }
+    const bool changed = (b7 != prev_b7) || (b8 != prev_b8) || (b9 != prev_b9);
+    const bool armable = (state == WAKE_IDLE || state == WAKE_DONE || state == WAKE_PENDING_PRESS);
+    prev_b7 = b7; prev_b8 = b8; prev_b9 = b9;
     critical_section_exit(&wake_cs);
 
-    if (act) {
-        // Safe no-op if the host did not enable remote wakeup. We still proceed
-        // through the FSM and try to send the key once the host resumes.
-        tud_remote_wakeup();
+    if (changed && armable) {
+        if (tud_remote_wakeup()) {
+            critical_section_enter_blocking(&wake_cs);
+            state = WAKE_REQUESTED;
+            state_entered_us = time_us_64();
+            critical_section_exit(&wake_cs);
+        }
     }
 }
 
 void wake_on_bt_disconnect(void) {
     critical_section_enter_blocking(&wake_cs);
     state = WAKE_IDLE;
-    prev_ps_bit = 1;
+    prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
     critical_section_exit(&wake_cs);
 }
 

--- a/src/wake.h
+++ b/src/wake.h
@@ -1,0 +1,22 @@
+//
+// Created by awalol on 2026/4/30.
+//
+
+#ifndef DS5_BRIDGE_WAKE_H
+#define DS5_BRIDGE_WAKE_H
+
+#include <cstdint>
+
+#ifdef ENABLE_WAKE_HID
+void wake_init(void);
+void wake_on_bt_input(const uint8_t *hid_input, uint16_t len);
+void wake_on_bt_disconnect(void);
+void wake_task(void);
+#else
+static inline void wake_init(void) {}
+static inline void wake_on_bt_input(const uint8_t *, uint16_t) {}
+static inline void wake_on_bt_disconnect(void) {}
+static inline void wake_task(void) {}
+#endif
+
+#endif //DS5_BRIDGE_WAKE_H


### PR DESCRIPTION
先前的方法是将 SetStateData 与音频数据装在一个数据包一起发送，但是会导致异环的自适应扳机工作异常。
这次更新将 SetStateData 和音频数据分开发送，但是增加了优先级，当有音频数据的时候会优先发送，发送完成以后再发送状态数据。