### PR TITLE
fix(wake): fix wake from S3 on Linux across consecutive sleep cycles

### DIFF
--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -8,8 +8,8 @@
 
 #include <cstdio>
 #include <cstring>
-
 #include "tusb.h"
+#include "device/dcd.h"
 #include "pico/sync.h"
 #include "pico/time.h"
 
@@ -76,17 +76,26 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
     WAKE_DBG("tud_suspend_cb remote_wakeup_en=%d prev_state=%s",
              (int)remote_wakeup_en, wake_state_name(state));
     host_suspended = true;
-    if (state == WAKE_IDLE || state == WAKE_DONE) {
-        state = WAKE_PENDING_PRESS;
-        state_entered_us = time_us_64();
-        prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
-        key_attempts = 0;
-        WAKE_DBG("-> PENDING_PRESS");
-    }
+    host_resumed_event = false;
+    
+    // Unconditionally re-arm on suspend. If a previous wake attempt hung
+    // (e.g. Linux ignored a keystroke and left the endpoint busy forever),
+    // we must abort and reset so the NEXT wake attempt can trigger.
+    state = WAKE_PENDING_PRESS;
+    state_entered_us = time_us_64();
+    prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
+    key_attempts = 0;
+    WAKE_DBG("-> PENDING_PRESS");
 }
 
 extern "C" void tud_resume_cb(void) {
     WAKE_DBG("tud_resume_cb state=%s", wake_state_name(state));
+    host_suspended = false;
+    host_resumed_event = true;
+}
+
+extern "C" void tud_mount_cb(void) {
+    WAKE_DBG("tud_mount_cb state=%s", wake_state_name(state));
     host_suspended = false;
     host_resumed_event = true;
 }
@@ -124,7 +133,17 @@ void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
     critical_section_exit(&wake_cs);
 
     if (changed && armable) {
-        const bool ok = tud_remote_wakeup();
+        bool ok = tud_remote_wakeup();
+        
+        // Linux quirk: Sometimes Linux fails to set the REMOTE_WAKEUP feature
+        // flag before the second suspend, causing TinyUSB to refuse to wake.
+        // If we are suspended but ok is false, we force the wake signal.
+        if (!ok && host_suspended) {
+            WAKE_DBG("tud_remote_wakeup()=0 but suspended. Forcing DCD wake.");
+            dcd_remote_wakeup(0);
+            ok = true;
+        }
+
         if (ok) {
             critical_section_enter_blocking(&wake_cs);
             state = WAKE_REQUESTED;


### PR DESCRIPTION
**Full transparency:** completely vibecoded fix and PR description. 

Tests:
- multiple cycles of wake from S3 on PC with Bazzite OS ✅
- multiple cycles of wake from S5 on the same PC with compatible(!, ASRock H370M-ITX/ac) motherboard: no regression ✅
- multiple cycles of wake from S3 on Windows PC: no regression ✅

**Full transparency:** Bellow is explanation from Gemini 3.1 Pro on what it actually did. 
***

### Fixes for "Second Wake from S3 Fails" on Linux/Bazzite OS

The discrepancy between how Windows and Linux handle USB resume exposed two hidden failure modes in the wake state machine. Fixing these ensures reliable wake from S3 across consecutive sleep cycles on Linux without breaking existing Windows behavior.

#### 1. Unconditional State Machine Reset on Suspend
**The Problem:** Linux often drops or ignores the initial HID wake keystroke (F15) because its USB input stack isn't fully ready when the keystroke is sent. Because Linux never acknowledges pulling the HID report, TinyUSB marks the IN endpoint as permanently "Busy" (`!tud_hid_n_ready()`). Because there is no timeout for this busy wait, the dongle's state machine hangs permanently. 
When the PC goes back to sleep (S3), `tud_suspend_cb()` was previously checking `if (state == WAKE_IDLE || state == WAKE_DONE)` before re-arming the dongle for the next wake. Because the state machine was hung on the busy endpoint, it bypassed the re-arm, permanently ignoring all future wake attempts until a hard replug.

**The Fix:** Removed the state check in `tud_suspend_cb()`. When the host suspends the bus, any pending or stuck operations are now unconditionally aborted, and the state machine is hard-reset to `WAKE_PENDING_PRESS` to arm for the next wake attempt.

#### 2. Bypassing `REMOTE_WAKEUP` Flag Drops (Linux Quirk)
**The Problem:** The dongle strictly relied on `tud_remote_wakeup()` to wake the PC. TinyUSB strictly enforces the USB specification: if the host did not explicitly enable the remote wakeup feature via a `SET_FEATURE(DEVICE_REMOTE_WAKEUP)` control request before suspending, `tud_remote_wakeup()` silently returns `false` and does nothing. 
Linux has a notorious USB power management quirk where, if a bus reset occurs during a wake cycle, it sometimes forgets to re-enable the `REMOTE_WAKEUP` feature flag before putting the port back to sleep for the *second* time. 

**The Fix:** Added a fallback in `wake_on_bt_input()`. If `tud_remote_wakeup()` returns `false` but we know the host is suspended (`host_suspended == true`), we bypass TinyUSB's software check and forcefully assert the hardware resume signaling by calling `dcd_remote_wakeup(0)`.