### PR TITLE
fix: extend inactivity detection to all primary inputs

### DIFF
--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -340,7 +340,13 @@ static void l2cap_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t 
             if (get_config().disable_inactive_disconnect) {
                 return;
             }
-            if (packet[3] < 120 || packet[3] > 140) {
+            if (packet[3] < 120 || packet[3] > 140 ||
+                packet[4] < 120 || packet[4] > 140 ||
+                packet[5] < 120 || packet[5] > 140 ||
+                packet[6] < 120 || packet[6] > 140 ||
+                packet[7] > 0 || packet[8] > 0 ||
+                packet[10] != 0x08 || packet[11] != 0x00 ||
+                packet[12] != 0x00) {
                 inactive_time = get_absolute_time();
             } else if (absolute_time_diff_us(inactive_time, get_absolute_time()) >
                        static_cast<int64_t>(get_config().inactive_time) * 60 * 1000 * 1000) {


### PR DESCRIPTION
## Summary
- Upstream only checks the left stick X axis for inactivity, so pressing buttons, using the d-pad, or moving the right stick won't prevent disconnection
- Extends the same dead zone pattern to cover both sticks (all 4 axes), both button bytes, and d-pad/misc bytes

## Details
Uses the same 120-140 dead zone range already in place for `packet[3]`, applied to:
- `packet[3-6]`     - stick axes (dead zone handles analog jitter at neutral)
- `packet[7-8]`     - button bytes (idle = 0)
- `packet[10-12]` - d-pad neutral (0x08) and remaining button bits (0x00)

## Test plan
- [x] Verified controller stays connected while using d-pad, buttons, or right stick without touching left stick
- [x] Verified controller still disconnects after configured timeout when truly idle
- [x] Verified analog stick jitter at neutral doesn't reset the timer