### PR TITLE
fix(batt-led): clear blink state on disconnect to stop runaway blinking

### DIFF
--- a/src/battery_led.cpp
+++ b/src/battery_led.cpp
@@ -37,11 +37,29 @@ void battery_led_note_report(void) {
     last_report_us = time_us_64();
 }
 
+void battery_led_on_disconnect(void) {
+    // Stop any in-progress blink and force the LED off immediately. Zero
+    // last_report_us so the tick's stale-check early-returns until a fresh
+    // 0x31 report arrives on the next connection — prevents the cached
+    // low-battery byte from re-arming a blink during reconnect retries.
+    blinking = false;
+    led_state = false;
+    last_report_us = 0;
+    last_toggle_us = 0;
+    cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
+}
+
 void battery_led_tick(void) {
     const uint64_t now = time_us_64();
     if (last_report_us == 0 || (now - last_report_us) >= REPORT_STALE_US) {
-        // No fresh data — bt.cpp owns the LED while disconnected.
-        blinking = false;
+        // No fresh data — bt.cpp owns the LED while disconnected. If we
+        // were mid-blink when the report went stale, force the LED off
+        // so it doesn't freeze in whichever half-cycle it was in.
+        if (blinking) {
+            blinking = false;
+            led_state = false;
+            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
+        }
         return;
     }
 

--- a/src/battery_led.h
+++ b/src/battery_led.h
@@ -16,3 +16,11 @@ void battery_led_tick(void);
 // has been copied into interrupt_in_data. Used to detect disconnection
 // via stale-report timeout.
 void battery_led_note_report(void);
+
+// Call from the BT disconnect handler. Cancels any in-progress blink,
+// forces the LED off, and arms the module so it ignores the cached
+// (now-stale) battery byte until a fresh report arrives on the next
+// connection. Without this, the LED can stay frozen in whichever state
+// it was at the moment of disconnect, or briefly resume blinking during
+// reconnect retries while interrupt_in_data[52] still reads low.
+void battery_led_on_disconnect(void);

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -18,6 +18,9 @@
 #include "config.h"
 #include "state_mgr.h"
 #include "pico/util/queue.h"
+#if ENABLE_BATT_LED
+#include "battery_led.h"
+#endif
 
 #define MTU_CONTROL 672
 #define MTU_INTERRUPT 672
@@ -342,6 +345,9 @@ static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
             hid_interrupt_cid = 0;
             feature_data.clear();
             cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
+#if ENABLE_BATT_LED
+            battery_led_on_disconnect();
+#endif
             printf("[HCI] Disconnected reason=0x%02X, start inquiry\n", reason);
             gap_inquiry_start(30);
             break;


### PR DESCRIPTION
## What's broken

When the DualSense's battery is low enough to trigger `battery_led_tick`'s blink (`PowerPercent <= 1` discharging) and the controller subsequently disconnects — most commonly because the battery fully depletes and the BT link drops — the Pico's onboard LED stays frozen in whichever half-cycle it was in at the moment of disconnect. In some reconnect-retry scenarios it can briefly resume blinking on its own.

Reported on Discord (Sura Academy):
> the pico led keeps blinking after the controller has died and fully lost connection. and never stops … not only will it keep blinking while the pc is on, but because it technically stays powered while the pc is off, it will just keep blinking forever.

## Root cause

Two related gaps:

1. `battery_led_tick` (`src/battery_led.cpp`) already has a 2-second stale-report check that sets `blinking = false` and returns, but it never turns the LED off. Whichever state the LED was in (ON or OFF) when staleness fired, it stays there until the next connection.
2. `bt.cpp`'s `HCI_EVENT_DISCONNECTION_COMPLETE` handler turns the LED off, but the battery_led module is unaware and the cached `interrupt_in_data[52]` still reads low. On the next tick — if `last_report_us` hasn't yet aged past the 2-second window — the module re-toggles the LED, undoing bt.cpp's work.

## Fix

- **New `battery_led_on_disconnect()`** clears blink state, forces the LED off, and zeros `last_report_us`. The zeroed timestamp makes the tick's existing `last_report_us == 0` early-return branch block any new blink until a *fresh* 0x31 report arrives on the next connection. Matches Sura's exact ask: *"don't blink again until the pico reads that the dualsense is in a low battery state again."*
- **Called from `bt.cpp`'s `HCI_EVENT_DISCONNECTION_COMPLETE`** (gated on `#if ENABLE_BATT_LED`).
- **Stale-check in `battery_led_tick` also now forces LED off** when it fires while a blink was in progress. Defense in depth for unclean disconnects.

Total: ~30 LOC across 3 files, no behavior change for any non-low-battery / non-disconnect path.

## Test plan

Verified on hardware (Pico 2 W + DualSense):

- [x] Temporarily raised \`THRESHOLD_LEVEL\` from 1 to 8 so the blink fires at any battery state (no waiting for actual depletion). Reverted in the committed change.
- [x] Paired → onboard LED started blinking immediately
- [x] Held PS for 10 seconds (power off controller) → LED went dark within 2 seconds and stayed dark
- [x] With controller off, watched for 30 seconds → LED remained off
- [x] Re-paired → fresh 0x31 report arrived, blink correctly resumed
- [x] \`THRESHOLD_LEVEL\` restored to 1 before this commit

## Files

- \`src/battery_led.h\` — public function declaration
- \`src/battery_led.cpp\` — implementation + stale-check LED-off
- \`src/bt.cpp\` — include + one call in disconnect handler

Happy to iterate on naming or style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)