### PR TITLE
Add PS button tap/hold macros (Win+G / Win+Tab) to launch Xbox Game Bar and Task Viewer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,8 @@ if(ENABLE_WAKE_HID)
     )
     target_sources(ds5-bridge PRIVATE
             src/wake.cpp
-    )
+            src/ps_shortcut.cpp
+     )
 endif()
 
 option(WAKE_DEBUG "Print wake-FSM transitions to UART (developer use)" OFF)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -100,6 +100,10 @@ void config_valid() {
         body->disable_usb_sn = 0;
         printf("[Config] Warning: disable_usb_sn is invalid\n");
     }
+    if (body->ps_shortcut_enabled > 1) {
+        body->ps_shortcut_enabled = 0;
+        printf("[Config] ps_shortcut_enabled is invalid\n");
+    }
 }
 
 void config_load() {

--- a/src/config.h
+++ b/src/config.h
@@ -22,6 +22,7 @@ struct __attribute__((packed)) Config_body {
     uint8_t controller_mode; // 0: DS5, 1: DSE, 2: Auto
     uint8_t lock_volume; // 0: disable,1: enable
     uint8_t disable_usb_sn; // 0: disable,1: enable
+    uint8_t ps_shortcut_enabled; // 0: disabled, 1: enabled (ENABLE_WAKE_HID only)
 };
 
 struct __attribute__((packed)) Config {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,9 @@
 #include "resample.h"
 #include "audio.h"
 #include "wake.h"
+#ifdef ENABLE_WAKE_HID
+#include "ps_shortcut.h"
+#endif
 #include "hardware/clocks.h"
 #include "hardware/vreg.h"
 #include "hardware/watchdog.h"
@@ -94,6 +97,9 @@ void on_bt_data(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
         // diff for edge detection) and short-circuiting it on non-2 polling
         // modes silently breaks wake while the host is suspended.
         wake_on_bt_input(data + 3, len - 3);
+        #ifdef ENABLE_WAKE_HID
+        ps_shortcut_tick(data + 3, len - 3);
+        #endif
 
         if (get_config().polling_rate_mode != 2) {
             memcpy(interrupt_in_data, data + 3, 63);

--- a/src/ps_shortcut.cpp
+++ b/src/ps_shortcut.cpp
@@ -1,0 +1,76 @@
+﻿#include "ps_shortcut.h"
+#include "config.h"
+#include "tusb.h"
+#include "class/hid/hid.h"
+#include "pico/time.h"
+
+#define PS_KBD_INSTANCE 1
+
+static bool ps_was_pressed       = false;
+static uint32_t ps_press_time    = 0;
+static bool long_press_fired     = false;
+static bool key_release_pending  = false;
+static uint32_t key_release_time = 0;
+static uint32_t last_high_time   = 0;
+static bool is_ps_pressed        = false;
+
+void ps_shortcut_reset() {
+    if (key_release_pending && tud_hid_n_ready(PS_KBD_INSTANCE)) {
+        tud_hid_n_keyboard_report(PS_KBD_INSTANCE, 0, 0, NULL);
+    }
+    ps_was_pressed      = false;
+    ps_press_time       = 0;
+    long_press_fired    = false;
+    key_release_pending = false;
+    key_release_time    = 0;
+    last_high_time      = 0;
+    is_ps_pressed       = false;
+}
+
+void ps_shortcut_tick(const uint8_t *data, uint16_t len) {
+    if (len < 10) return;
+    if (!get_config().ps_shortcut_enabled) return;
+
+    uint32_t now = to_ms_since_boot(get_absolute_time());
+    bool raw_ps = (data[9] & 0x01) != 0;
+
+    if (raw_ps) {
+        is_ps_pressed = true;
+        last_high_time = now;
+    } else if (now - last_high_time > 50) {
+        is_ps_pressed = false;
+    }
+
+    if (key_release_pending && now >= key_release_time) {
+        if (tud_hid_n_ready(PS_KBD_INSTANCE)) {
+            tud_hid_n_keyboard_report(PS_KBD_INSTANCE, 0, 0, NULL);
+            key_release_pending = false;
+        }
+    }
+
+    if (is_ps_pressed && !ps_was_pressed) {
+        ps_press_time    = now;
+        ps_was_pressed   = true;
+        long_press_fired = false;
+    } else if (is_ps_pressed && ps_was_pressed) {
+        if (!long_press_fired && (now - ps_press_time >= 750)) {
+            if (tud_hid_n_ready(PS_KBD_INSTANCE)) {
+                uint8_t keys[6] = { HID_KEY_TAB };
+                tud_hid_n_keyboard_report(PS_KBD_INSTANCE, 0, KEYBOARD_MODIFIER_LEFTGUI, keys);
+                long_press_fired    = true;
+                key_release_pending = true;
+                key_release_time    = now + 30;
+            }
+        }
+    } else if (!is_ps_pressed && ps_was_pressed) {
+        if (!long_press_fired) {
+            if (tud_hid_n_ready(PS_KBD_INSTANCE)) {
+                uint8_t keys[6] = { HID_KEY_G };
+                tud_hid_n_keyboard_report(PS_KBD_INSTANCE, 0, KEYBOARD_MODIFIER_LEFTGUI, keys);
+                key_release_pending = true;
+                key_release_time    = now + 30;
+            }
+        }
+        ps_was_pressed = false;
+    }
+}

--- a/src/ps_shortcut.h
+++ b/src/ps_shortcut.h
@@ -1,0 +1,6 @@
+﻿#pragma once
+
+#include <cstdint>
+
+void ps_shortcut_tick(const uint8_t *data, uint16_t len);
+void ps_shortcut_reset();

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -13,6 +13,8 @@
 #include "device/dcd.h"
 #include "pico/sync.h"
 #include "pico/time.h"
+#include "ps_shortcut.h"
+
 
 #define WAKE_KBD_INSTANCE     1
 #define WAKE_KEYCODE_F15      0x68
@@ -186,6 +188,7 @@ void wake_on_bt_disconnect(void) {
     state = WAKE_IDLE;
     prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
     critical_section_exit(&wake_cs);
+    ps_shortcut_reset();
 }
 
 void wake_task(void) {


### PR DESCRIPTION
currently, windows does not allow the dualsense controller to open the windows gamebar by pressing the ps button. 

this adds Windows shortcuts (Win+G / Win+Tab) on ps button press press. 

when the ps button is tapped, the xbox game bar will open.  (win+g)
when it is held down, the windows taskview will open. (win+tab)

the ps button now functions identical to how the xbox guide button (xbox logo) functions on an xbox controller. 


i refactored the build to compile within the usb wake variant. it utilizes the same keyboard used to wake the pc. 
after building with -Variant wake, the feature will still be disabled be default, and is enable-able via the web config. 
```
(`ps_shortcut_enabled` )
`uint8_t` (`0` = disabled, `1` = enabled)
```

example web config field: 
<img width="556" height="148" alt="{DA60590F-C98B-4DCE-B211-1601112D7DA2}" src="https://github.com/user-attachments/assets/b83ecdd4-d1b6-4b90-87ef-d54c21c985e8" />




