### PR TITLE
feat(wake): power off DualSense on sleep and wake PC on reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+.deps
 .vscode
 .idea
 example

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ To build the project from source:
 1. ***Update TinyUSB in the Pico SDK to the latest version***
 2. Compile using standard Pico SDK toolchain
 
+On macOS, `tools/build-macos.sh` can prepare a repo-local Pico SDK checkout, prompt to install missing Homebrew build tools, initialize submodules, pin TinyUSB, and build the wake firmware:
+
+```sh
+tools/build-macos.sh
+```
+
+Use `tools/build-macos.sh --standard` for the non-wake firmware, `--clean` to rebuild from scratch, or `--sdk-dir <path>` to use an existing SDK checkout. When using `--sdk-dir`, the script asks before checking that SDK out to the required Pico SDK and TinyUSB versions.
+
 ## Wake-on-PS (optional)
 
 A `-DENABLE_WAKE_HID=ON` build adds a second HID interface (a boot keyboard) that injects an **F15** keypress when any controller button is pressed while the host is suspended, waking the PC from **S3 sleep**. F15 was chosen because it has no default Windows or app binding — a stray fire never inserts characters or triggers shortcuts.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ On macOS, `tools/build-macos.sh` can prepare a repo-local Pico SDK checkout, pro
 tools/build-macos.sh
 ```
 
-Use `tools/build-macos.sh --standard` for the non-wake firmware, `--clean` to rebuild from scratch, or `--sdk-dir <path>` to use an existing SDK checkout. When using `--sdk-dir`, the script asks before checking that SDK out to the required Pico SDK and TinyUSB versions.
+Use `tools/build-macos.sh --standard` for the non-wake firmware, `--clean` to rebuild from scratch, or `--sdk-dir <path>` to use an existing SDK checkout. When using `--sdk-dir`, the script asks before checking that SDK out to the required Pico SDK and TinyUSB versions. If Homebrew's `arm-none-eabi-gcc` formula is installed without standard C headers, the script asks to install the complete `gcc-arm-embedded` cask and points CMake at that toolchain.
 
 ## Wake-on-PS (optional)
 

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -17,6 +17,7 @@
 #include "classic/sdp_server.h"
 #include "config.h"
 #include "state_mgr.h"
+#include "wake.h"
 #include "pico/util/queue.h"
 
 #define MTU_CONTROL 672
@@ -463,6 +464,8 @@ static void l2cap_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t 
 
                     const auto mtu = l2cap_get_remote_mtu_for_local_cid(hid_interrupt_cid);
                     printf("[L2CAP] Remote Interrupt MTU: %d\n",mtu);
+
+                    wake_on_bt_connect();
 
                     gap_connectable_control(false);
                     gap_discoverable_control(false);

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -587,6 +587,12 @@ void set_feature_data(uint8_t reportId, uint8_t *data, uint16_t len) {
     }
 }
 
+void bt_power_off_controller() {
+    uint8_t bluetooth_control[47]{};
+    bluetooth_control[0] = 0x02; // DualSense Bluetooth control: 1=on, 2=off.
+    set_feature_data(0x08, bluetooth_control, sizeof(bluetooth_control));
+}
+
 void init_feature() {
     get_feature_data(0x09, 20);
     get_feature_data(0x20, 64);

--- a/src/bt.h
+++ b/src/bt.h
@@ -19,6 +19,7 @@ int bt_init();
 void bt_register_data_callback(bt_data_callback_t callback);
 void bt_send_packet(uint8_t *data, uint16_t len);
 void bt_send_control(uint8_t *data, uint16_t len);
+void bt_power_off_controller();
 void bt_write(const uint8_t *data, uint16_t len);
 void bt_get_signal_strength(int8_t *rssi);
 std::vector<uint8_t> get_feature_data(uint8_t reportId,uint16_t len);

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -69,6 +69,37 @@ static void enter_state(wake_state_t s) {
     state_entered_us = time_us_64();
 }
 
+static void request_host_wake(const char *reason) {
+    bool ok = tud_remote_wakeup();
+
+    // Linux quirk: Sometimes Linux fails to set the REMOTE_WAKEUP feature
+    // flag before the second suspend, causing TinyUSB to refuse to wake.
+    // If we are suspended but ok is false, we force the wake signal.
+    if (!ok && host_suspended) {
+        WAKE_DBG("%s: tud_remote_wakeup()=0 but suspended. Forcing DCD wake.", reason);
+        dcd_remote_wakeup(0);
+        ok = true;
+    }
+
+    if (ok) {
+        critical_section_enter_blocking(&wake_cs);
+        state = WAKE_REQUESTED;
+        state_entered_us = time_us_64();
+        critical_section_exit(&wake_cs);
+        WAKE_DBG("%s -> REQUESTED", reason);
+    }
+#ifdef WAKE_DEBUG
+    else {
+        static uint64_t last_log = 0;
+        const uint64_t now = time_us_64();
+        if (now - last_log > 5000000) {
+            WAKE_DBG("%s, tud_remote_wakeup()=0 (USB bus not in suspend) -- 5s heartbeat", reason);
+            last_log = now;
+        }
+    }
+#endif
+}
+
 void wake_init(void) {
     critical_section_init(&wake_cs);
 }
@@ -88,6 +119,17 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
     prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
     key_attempts = 0;
     WAKE_DBG("-> PENDING_PRESS");
+}
+
+void wake_on_bt_connect(void) {
+    critical_section_enter_blocking(&wake_cs);
+    const bool should_wake = host_suspended &&
+        (state == WAKE_IDLE || state == WAKE_DONE || state == WAKE_PENDING_PRESS);
+    critical_section_exit(&wake_cs);
+
+    if (should_wake) {
+        request_host_wake("BT reconnect while suspended");
+    }
 }
 
 extern "C" void tud_resume_cb(void) {
@@ -135,34 +177,7 @@ void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
     critical_section_exit(&wake_cs);
 
     if (changed && armable) {
-        bool ok = tud_remote_wakeup();
-        
-        // Linux quirk: Sometimes Linux fails to set the REMOTE_WAKEUP feature
-        // flag before the second suspend, causing TinyUSB to refuse to wake.
-        // If we are suspended but ok is false, we force the wake signal.
-        if (!ok && host_suspended) {
-            WAKE_DBG("tud_remote_wakeup()=0 but suspended. Forcing DCD wake.");
-            dcd_remote_wakeup(0);
-            ok = true;
-        }
-
-        if (ok) {
-            critical_section_enter_blocking(&wake_cs);
-            state = WAKE_REQUESTED;
-            state_entered_us = time_us_64();
-            critical_section_exit(&wake_cs);
-            WAKE_DBG("button event -> REQUESTED, tud_remote_wakeup()=1");
-        }
-#ifdef WAKE_DEBUG
-        else {
-            static uint64_t last_log = 0;
-            const uint64_t now = time_us_64();
-            if (now - last_log > 5000000) {
-                WAKE_DBG("button event, tud_remote_wakeup()=0 (USB bus not in suspend) -- 5s heartbeat");
-                last_log = now;
-            }
-        }
-#endif
+        request_host_wake("button event");
     }
 }
 

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include "bt.h"
 #include "tusb.h"
 #include "device/dcd.h"
 #include "pico/sync.h"
@@ -75,6 +76,7 @@ void wake_init(void) {
 extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
     WAKE_DBG("tud_suspend_cb remote_wakeup_en=%d prev_state=%s",
              (int)remote_wakeup_en, wake_state_name(state));
+    bt_power_off_controller();
     host_suspended = true;
     host_resumed_event = false;
     

--- a/src/wake.h
+++ b/src/wake.h
@@ -9,11 +9,13 @@
 
 #ifdef ENABLE_WAKE_HID
 void wake_init(void);
+void wake_on_bt_connect(void);
 void wake_on_bt_input(const uint8_t *hid_input, uint16_t len);
 void wake_on_bt_disconnect(void);
 void wake_task(void);
 #else
 static inline void wake_init(void) {}
+static inline void wake_on_bt_connect(void) {}
 static inline void wake_on_bt_input(const uint8_t *, uint16_t) {}
 static inline void wake_on_bt_disconnect(void) {}
 static inline void wake_task(void) {}

--- a/tools/build-macos.sh
+++ b/tools/build-macos.sh
@@ -10,6 +10,7 @@ SDK_DIR=""
 DEFAULT_SDK_DIR=""
 USING_DEFAULT_SDK="ON"
 CLEAN_BUILD="OFF"
+PICO_TOOLCHAIN_PATH=""
 
 usage() {
   cat <<'USAGE'
@@ -24,7 +25,7 @@ Options:
   --sdk-dir <path>    Use this Pico SDK checkout instead of .deps/pico-sdk.
   -h, --help          Show this help.
 
-The script prompts before installing missing Homebrew packages.
+The script prompts before installing missing Homebrew packages or casks.
 USAGE
 }
 
@@ -47,6 +48,29 @@ repo_root() {
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
   cd "$script_dir/.." && pwd -P
+}
+
+compiler_has_headers() {
+  local compiler="$1"
+  local obj
+  obj="$(mktemp "${TMPDIR:-/tmp}/ds5dongle-compiler-test.XXXXXX.o")"
+  printf '#include <stdint.h>\n#include <stdlib.h>\nint main(void) { return 0; }\n' |
+    "$compiler" -x c - -c -o "$obj" >/dev/null 2>&1
+  local status=$?
+  rm -f "$obj"
+  return "$status"
+}
+
+find_arm_cask_toolchain() {
+  local candidate
+  for candidate in /Applications/ArmGNUToolchain/*/arm-none-eabi; do
+    if [[ -x "$candidate/bin/arm-none-eabi-gcc" ]] &&
+      compiler_has_headers "$candidate/bin/arm-none-eabi-gcc"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
 }
 
 while [[ $# -gt 0 ]]; do
@@ -119,7 +143,6 @@ command -v git >/dev/null 2>&1 || die "git is required"
 missing_brew_packages=()
 command -v cmake >/dev/null 2>&1 || missing_brew_packages+=("cmake")
 command -v ninja >/dev/null 2>&1 || missing_brew_packages+=("ninja")
-command -v arm-none-eabi-gcc >/dev/null 2>&1 || missing_brew_packages+=("arm-none-eabi-gcc")
 
 if [[ ${#missing_brew_packages[@]} -gt 0 ]]; then
   command -v brew >/dev/null 2>&1 || die "Homebrew is required to install: ${missing_brew_packages[*]}"
@@ -128,6 +151,26 @@ if [[ ${#missing_brew_packages[@]} -gt 0 ]]; then
     brew install "${missing_brew_packages[@]}"
   else
     die "missing required build dependencies"
+  fi
+fi
+
+if command -v arm-none-eabi-gcc >/dev/null 2>&1 &&
+  compiler_has_headers "$(command -v arm-none-eabi-gcc)"; then
+  echo "Using ARM toolchain: $(command -v arm-none-eabi-gcc)"
+else
+  if PICO_TOOLCHAIN_PATH="$(find_arm_cask_toolchain)"; then
+    echo "Using ARM toolchain: $PICO_TOOLCHAIN_PATH/bin/arm-none-eabi-gcc"
+  else
+    command -v brew >/dev/null 2>&1 || die "Homebrew is required to install gcc-arm-embedded"
+    echo "The available arm-none-eabi-gcc is missing standard C headers."
+    echo "Homebrew's arm-none-eabi-gcc formula is built without newlib headers; this firmware needs the complete Arm GNU toolchain."
+    if confirm "Install the Homebrew gcc-arm-embedded cask?"; then
+      brew install --cask gcc-arm-embedded
+    else
+      die "missing a complete ARM embedded toolchain"
+    fi
+    PICO_TOOLCHAIN_PATH="$(find_arm_cask_toolchain)" || die "gcc-arm-embedded was installed, but no usable toolchain was found"
+    echo "Using ARM toolchain: $PICO_TOOLCHAIN_PATH/bin/arm-none-eabi-gcc"
   fi
 fi
 
@@ -170,11 +213,26 @@ if [[ "$CLEAN_BUILD" == "ON" ]]; then
   rm -rf "$BUILD_DIR"
 fi
 
-echo "Configuring firmware..."
-cmake -S . -B "$BUILD_DIR" -G Ninja \
-  -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-  -DPICO_SDK_PATH="$SDK_DIR" \
+CMAKE_ARGS=(
+  -S .
+  -B "$BUILD_DIR"
+  -G Ninja
+  -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+  -DPICO_SDK_PATH="$SDK_DIR"
   -DENABLE_WAKE_HID="$ENABLE_WAKE_HID"
+)
+
+if [[ -n "$PICO_TOOLCHAIN_PATH" ]]; then
+  CMAKE_ARGS+=(-DPICO_TOOLCHAIN_PATH="$PICO_TOOLCHAIN_PATH")
+  if [[ -f "$BUILD_DIR/CMakeCache.txt" ]] &&
+    ! grep -q "^CMAKE_C_COMPILER:FILEPATH=$PICO_TOOLCHAIN_PATH/bin/arm-none-eabi-gcc$" "$BUILD_DIR/CMakeCache.txt"; then
+    echo "Removing $BUILD_DIR because it was configured with a different ARM compiler."
+    rm -rf "$BUILD_DIR"
+  fi
+fi
+
+echo "Configuring firmware..."
+cmake "${CMAKE_ARGS[@]}"
 
 echo "Building firmware..."
 cmake --build "$BUILD_DIR" --target ds5-bridge

--- a/tools/build-macos.sh
+++ b/tools/build-macos.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PICO_SDK_VERSION="2.2.0"
+TINYUSB_VERSION="0.20.0"
+BUILD_TYPE="Release"
+BUILD_DIR="build/wake"
+ENABLE_WAKE_HID="ON"
+SDK_DIR=""
+DEFAULT_SDK_DIR=""
+USING_DEFAULT_SDK="ON"
+CLEAN_BUILD="OFF"
+
+usage() {
+  cat <<'USAGE'
+Usage: tools/build-macos.sh [options]
+
+Build DS5Dongle on macOS using a repo-local Pico SDK checkout.
+
+Options:
+  --standard          Build standard firmware without ENABLE_WAKE_HID.
+  --wake              Build wake firmware with ENABLE_WAKE_HID (default).
+  --clean             Remove the selected build directory before configuring.
+  --sdk-dir <path>    Use this Pico SDK checkout instead of .deps/pico-sdk.
+  -h, --help          Show this help.
+
+The script prompts before installing missing Homebrew packages.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+confirm() {
+  local prompt="$1"
+  local answer
+  read -r -p "$prompt [y/N] " answer
+  case "$answer" in
+    y|Y|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+repo_root() {
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+  cd "$script_dir/.." && pwd -P
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --standard)
+      ENABLE_WAKE_HID="OFF"
+      BUILD_DIR="build/standard"
+      shift
+      ;;
+    --wake)
+      ENABLE_WAKE_HID="ON"
+      BUILD_DIR="build/wake"
+      shift
+      ;;
+    --clean)
+      CLEAN_BUILD="ON"
+      shift
+      ;;
+    --sdk-dir)
+      [[ $# -ge 2 ]] || die "--sdk-dir requires a path"
+      SDK_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  die "this script is intended for macOS"
+fi
+
+ROOT="$(repo_root)"
+cd "$ROOT"
+
+DEFAULT_SDK_DIR="$ROOT/.deps/pico-sdk"
+if [[ -z "$SDK_DIR" ]]; then
+  SDK_DIR="$DEFAULT_SDK_DIR"
+else
+  USING_DEFAULT_SDK="OFF"
+fi
+SDK_PARENT="$(cd "$(dirname "$SDK_DIR")" 2>/dev/null && pwd -P || true)"
+if [[ -n "$SDK_PARENT" ]]; then
+  SDK_DIR="$SDK_PARENT/$(basename "$SDK_DIR")"
+fi
+
+echo "Repository: $ROOT"
+echo "Pico SDK:   $SDK_DIR"
+echo "Build dir:  $BUILD_DIR"
+echo "Wake HID:   $ENABLE_WAKE_HID"
+echo
+
+if ! xcode-select -p >/dev/null 2>&1; then
+  echo "Xcode Command Line Tools are required."
+  if confirm "Open Apple's installer with xcode-select --install?"; then
+    xcode-select --install
+    echo "Re-run this script after the installer finishes."
+    exit 1
+  fi
+  die "Xcode Command Line Tools are missing"
+fi
+
+command -v git >/dev/null 2>&1 || die "git is required"
+
+missing_brew_packages=()
+command -v cmake >/dev/null 2>&1 || missing_brew_packages+=("cmake")
+command -v ninja >/dev/null 2>&1 || missing_brew_packages+=("ninja")
+command -v arm-none-eabi-gcc >/dev/null 2>&1 || missing_brew_packages+=("arm-none-eabi-gcc")
+
+if [[ ${#missing_brew_packages[@]} -gt 0 ]]; then
+  command -v brew >/dev/null 2>&1 || die "Homebrew is required to install: ${missing_brew_packages[*]}"
+  echo "Missing build dependencies: ${missing_brew_packages[*]}"
+  if confirm "Install missing packages with Homebrew?"; then
+    brew install "${missing_brew_packages[@]}"
+  else
+    die "missing required build dependencies"
+  fi
+fi
+
+echo "Initializing repository submodules..."
+git submodule update --init --recursive
+
+if [[ -e "$SDK_DIR" ]] && ! git -C "$SDK_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  die "$SDK_DIR exists but is not a Git checkout"
+fi
+
+if [[ -e "$SDK_DIR" ]] && [[ "$USING_DEFAULT_SDK" == "OFF" ]]; then
+  echo "The SDK at $SDK_DIR will be checked out to Pico SDK $PICO_SDK_VERSION,"
+  echo "and its TinyUSB submodule will be checked out to $TINYUSB_VERSION."
+  if ! confirm "Continue modifying this SDK checkout?"; then
+    die "refusing to modify user-provided SDK checkout"
+  fi
+fi
+
+if [[ ! -e "$SDK_DIR" ]]; then
+  mkdir -p "$(dirname "$SDK_DIR")"
+  echo "Cloning Pico SDK $PICO_SDK_VERSION..."
+  git clone https://github.com/raspberrypi/pico-sdk.git "$SDK_DIR"
+fi
+
+echo "Preparing Pico SDK $PICO_SDK_VERSION..."
+git -C "$SDK_DIR" fetch --tags
+git -C "$SDK_DIR" checkout "$PICO_SDK_VERSION"
+git -C "$SDK_DIR" submodule update --init --recursive
+
+TINYUSB_DIR="$SDK_DIR/lib/tinyusb"
+git -C "$TINYUSB_DIR" rev-parse --git-dir >/dev/null 2>&1 || die "TinyUSB submodule not found at $TINYUSB_DIR"
+
+echo "Preparing TinyUSB $TINYUSB_VERSION..."
+git -C "$TINYUSB_DIR" fetch --tags
+git -C "$TINYUSB_DIR" checkout "$TINYUSB_VERSION"
+git -C "$TINYUSB_DIR" submodule update --init --recursive
+
+if [[ "$CLEAN_BUILD" == "ON" ]]; then
+  echo "Removing $BUILD_DIR..."
+  rm -rf "$BUILD_DIR"
+fi
+
+echo "Configuring firmware..."
+cmake -S . -B "$BUILD_DIR" -G Ninja \
+  -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+  -DPICO_SDK_PATH="$SDK_DIR" \
+  -DENABLE_WAKE_HID="$ENABLE_WAKE_HID"
+
+echo "Building firmware..."
+cmake --build "$BUILD_DIR" --target ds5-bridge
+
+echo
+echo "Built firmware:"
+echo "  $ROOT/$BUILD_DIR/ds5-bridge.uf2"


### PR DESCRIPTION
 ## Summary

  This PR extends the experimental Wake-on-PS firmware with a power-saving sleep flow:

  - Powers off the connected DualSense when the host enters USB suspend/S3.
  - Wakes the host when the controller reconnects while suspended, allowing PS-button power-on to wake the PC without requiring a second button press.
  - Keeps the existing wake-on-button-report behavior as a fallback.
  - Adds a macOS helper script for building the wake firmware.

  ## Behavior

  With `ENABLE_WAKE_HID=ON`:

  1. PC enters S3 sleep.
  2. Pico receives USB suspend.
  3. Pico sends DualSense Bluetooth Control feature report `0x08` with state `0x02` to power off the controller.
  4. User presses PS.
  5. Controller powers on and reconnects to the Pico.
  6. Pico sends USB remote wake and the existing F15 wake keystroke.

  This avoids leaving the controller powered during PC sleep while keeping the PS-button wake flow usable.

  ## macOS Build Script

  Adds:

  ```sh
  tools/build-macos.sh
  ```

  The script:

  - Checks required build tools.
  - Prompts before installing missing Homebrew dependencies.
  - Uses a repo-local Pico SDK checkout under .deps/pico-sdk.
  - Pins Pico SDK 2.2.0.
  - Pins TinyUSB 0.20.0.
  - Builds the wake firmware by default.

  ## Testing

  Tested on macOS with a Pico 2 W wake build:

  - Firmware builds successfully.
  - Controller powers off when the PC enters sleep/suspend.
  - Pressing PS powers the controller on and reconnects to the Pico.
  - Reconnect wakes the PC without needing an additional controller button press.