### PR TITLE
Add Waveshare RP2350B-Plus-W as a build target

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -58,13 +58,13 @@ env:
   PICO_SDK_REF: 2.2.0
   TINYUSB_REF: 0.20.0
   PICO_SDK_PATH: ${{ github.workspace }}/pico-sdk
+  ARM_TOOLCHAIN_VERSION: 14.2.rel1
+  ARM_TOOLCHAIN_URL: https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
+  ARM_TOOLCHAIN_PATH: ${{ github.workspace }}/arm-toolchain
   APT_PACKAGES: >-
     cmake
     python3
     build-essential
-    gcc-arm-none-eabi
-    libnewlib-arm-none-eabi
-    libstdc++-arm-none-eabi-newlib
     ninja-build
 
 jobs:
@@ -118,6 +118,29 @@ jobs:
           sudo apt-get -o Dir::Cache::archives="${{ steps.apt-cache.outputs.dir }}" install --download-only -y $APT_PACKAGES
           sudo apt-get -o Dir::Cache::archives="${{ steps.apt-cache.outputs.dir }}" install -y $APT_PACKAGES
           sudo chmod -R a+rX "${{ steps.apt-cache.outputs.dir }}"
+
+      - name: Cache ARM toolchain
+        id: cache-arm-toolchain
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.ARM_TOOLCHAIN_PATH }}
+          key: ${{ runner.os }}-${{ runner.arch }}-arm-toolchain-${{ env.ARM_TOOLCHAIN_VERSION }}
+
+      - name: Download ARM toolchain
+        if: steps.cache-arm-toolchain.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$ARM_TOOLCHAIN_PATH"
+          curl -fsSL "$ARM_TOOLCHAIN_URL" | sudo tar -xJ -C "$ARM_TOOLCHAIN_PATH" --strip-components=1
+          sudo chmod -R a+rX "$ARM_TOOLCHAIN_PATH"
+
+      - name: Add ARM toolchain to PATH
+        run: |
+          echo "$ARM_TOOLCHAIN_PATH/bin" >> "$GITHUB_PATH"
+
+      - name: Verify ARM toolchain
+        run: |
+          which arm-none-eabi-gcc
+          arm-none-eabi-gcc --version
 
       - name: Cache Pico SDK
         id: cache-pico-sdk

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: boolean
         default: false
+      waveshare:
+        description: Also build the Waveshare RP2350B-Plus-W UF2 (-DWAVESHARE_RP2350B_PLUS_W_BUILD=ON)
+        required: false
+        type: boolean
+        default: false
       no_batt_led_check:
         description: Also compile-check the no-batt-led config (-DENABLE_BATT_LED=OFF)
         required: false
@@ -184,6 +189,19 @@ jobs:
           cmake --build build/picow --target ds5-bridge
           cp build/picow/ds5-bridge.uf2 "artifacts/ds5-bridge-picow${{ inputs.asset_suffix }}.uf2"
 
+      - name: Build Waveshare RP2350B-Plus-W firmware
+        if: inputs.waveshare
+        run: |
+          VERSION_ARG=()
+          [ -n "${FW_VER:-}" ] && VERSION_ARG=(-DVERSION="$FW_VER")
+          cmake -S . -B build/waveshare -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPICO_SDK_PATH="$PICO_SDK_PATH" \
+            -DWAVESHARE_RP2350B_PLUS_W_BUILD=ON \
+            "${VERSION_ARG[@]}"
+          cmake --build build/waveshare --target ds5-bridge
+          cp build/waveshare/ds5-bridge.uf2 "artifacts/ds5-bridge-waveshare${{ inputs.asset_suffix }}.uf2"
+
       - name: Build USB-Wake firmware
         if: inputs.picow
         run: |
@@ -241,6 +259,14 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           path: artifacts/ds5-bridge-picow${{ inputs.asset_suffix }}.uf2
+          archive: false
+          if-no-files-found: error
+
+      - name: Upload Waveshare UF2 artifact
+        if: inputs.waveshare
+        uses: actions/upload-artifact@v7
+        with:
+          path: artifacts/ds5-bridge-waveshare${{ inputs.asset_suffix }}.uf2
           archive: false
           if-no-files-found: error
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,6 @@ jobs:
     with:
       version: ${{ github.sha }}   # reusable build shortens a full SHA to 7
       picow: true
+      waveshare: true
       no_batt_led_check: true
       usbwake: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,12 @@ target_compile_options(ds5-bridge PRIVATE -fsigned-char)
 target_compile_definitions(wdl_resampler PRIVATE
         WDL_RESAMPLE_TYPE=float
 )
+if(${SYS_CLOCK_KHZ_VALUE} GREATER 266000)
+    set(PICO_FLASH_SPI_CLKDIV 4)
+else()
+    set(PICO_FLASH_SPI_CLKDIV 2)
+endif()
+target_compile_definitions(bs2_default PRIVATE PICO_FLASH_SPI_CLKDIV=${PICO_FLASH_SPI_CLKDIV})
 target_compile_definitions(ds5-bridge PRIVATE
         CYW43_LWIP=0
         ENABLE_SERIAL=${ENABLE_SERIAL_VALUE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,31 @@ if (EXISTS ${picoVscode})
 endif ()
 # ====================================================================================
 
+option(PICO_W_BUILD "Build for Rasberry Pi Pico W, audio is missing" OFF)
+option(WAVESHARE_RP2350B_PLUS_W_BUILD "Build for Waveshare RP2350B-Plus-W (USB-C, 16MB flash, RM2 wireless)" OFF)
+
+if (PICO_W_BUILD AND WAVESHARE_RP2350B_PLUS_W_BUILD)
+        message(FATAL_ERROR "PICO_W_BUILD and WAVESHARE_RP2350B_PLUS_W_BUILD are mutually exclusive")
+endif ()
+
 if (PICO_W_BUILD)
         set(PICO_BOARD pico_w CACHE STRING "Board type")
         set(PICO_RP2350 OFF CACHE BOOL "Not using RP2350")
+elseif (WAVESHARE_RP2350B_PLUS_W_BUILD)
+        set(PICO_BOARD waveshare_rp2350b_plus_w CACHE STRING "Board type")
+        # Waveshare board header is not in upstream pico-sdk; ship it here and
+        # tell the SDK to search this directory when resolving PICO_BOARD.
+        list(APPEND PICO_BOARD_HEADER_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/boards/headers")
 else ()
         set(PICO_BOARD pico2_w CACHE STRING "Board type")
 endif ()
+
+# Diagnostic: confirm PICO_BOARD resolution actually applied. Build log will
+# show which board path was taken. Remove these once verified on hardware.
+message(STATUS "DS5Dongle build target -- PICO_BOARD=${PICO_BOARD}")
+message(STATUS "DS5Dongle build target -- PICO_W_BUILD=${PICO_W_BUILD}")
+message(STATUS "DS5Dongle build target -- WAVESHARE_RP2350B_PLUS_W_BUILD=${WAVESHARE_RP2350B_PLUS_W_BUILD}")
+message(STATUS "DS5Dongle build target -- PICO_BOARD_HEADER_DIRS=${PICO_BOARD_HEADER_DIRS}")
 #set(PICO_CYW43_SUPPORTED 1)
 #set(PICO_CYW43_ARCH_THREADSAFE_BACKGROUND 1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,22 @@ else()
     set(PICO_FLASH_SPI_CLKDIV 2)
 endif()
 target_compile_definitions(bs2_default PRIVATE PICO_FLASH_SPI_CLKDIV=${PICO_FLASH_SPI_CLKDIV})
+
+# On RP2350, boot stage 2 is not executed unless PICO_EMBED_XIP_SETUP=1 is
+# defined. Without this, QMI XIP config (including PICO_FLASH_SPI_CLKDIV above)
+# is left at whatever the bootrom auto-detected from the flash chip's SFDP
+# table. For the Waveshare board (which ships with a Puya PY25Q128HA flash
+# chip rather than the schematic-listed Winbond W25Q128JVSIQ), the bootrom
+# defaults to CLKDIV=3 and Fast Read Dual I/O (0xBB) — which puts flash SPI
+# at 106.7MHz at 320MHz sys_clk, over Puya's 104MHz dual-mode spec. This
+# causes intermittent XIP read corruption that manifests as choppy audio.
+# Embedding boot2 forces boot2_w25q080 to actually run, applying our
+# PICO_FLASH_SPI_CLKDIV=4 (giving 80MHz flash SPI, well within Puya spec)
+# and switching to Fast Read Quad I/O (0xEB) for full bandwidth.
+if (WAVESHARE_RP2350B_PLUS_W_BUILD)
+    target_compile_definitions(ds5-bridge PRIVATE PICO_EMBED_XIP_SETUP=1)
+endif()
+
 target_compile_definitions(ds5-bridge PRIVATE
         CYW43_LWIP=0
         ENABLE_SERIAL=${ENABLE_SERIAL_VALUE}

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 [中文](./README.CN.md)
 
-> Turn a Raspberry Pi Pico2W into a wireless adapter for the DualSense (DS5) controller.
+> Turn a Raspberry Pi Pico2W (or other compatible board) into a wireless adapter for the DualSense (DS5) controller.
 
 ## Overview
 
-This project enables the Raspberry Pi Pico2W to function as a Bluetooth bridge for the DualSense controller, allowing wireless connectivity with enhanced haptics support.
+This project enables the Raspberry Pi Pico2W (or other compatible board, e.g. the Waveshare RP2350B-Plus-W) to function as a Bluetooth bridge for the DualSense controller, allowing wireless connectivity with enhanced haptics support.
 
 ## Features
 
-- 🎮 Full DualSense connectivity via Pico2W
+- 🎮 Full DualSense connectivity via Pico2W (or other compatible board)
 - 🔊 Supports HD haptics (advanced vibration feedback)
 - 📡 Wireless Bluetooth bridging
 
@@ -63,6 +63,16 @@ To opt out at build time, configure with `-DENABLE_BATT_LED=OFF`. Default is ON.
 
 Pico W only has haptics support, no speaker. You can enable Pico W firmware compilation with `-DPICO_W_BUILD=ON`, or download precompiled firmware from GitHub Actions.
 
+### Waveshare RP2350B-Plus-W
+
+The [Waveshare RP2350B-Plus-W](https://www.waveshare.com/wiki/RP2350B-Plus-W) is an RP2350B-based board with the RM2 wireless module (same CYW43 silicon as the Pico 2 W), 16 MB QSPI flash, and a USB-C connector. Build with:
+
+```
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+      -DPICO_SDK_PATH=<sdk> -DWAVESHARE_RP2350B_PLUS_W_BUILD=ON
+cmake --build build --target ds5-bridge
+```
+
 ### USB Wake Feature
 
 This feature is experimental. If you need this functionality, please check out the feat/usb-wake branch to compile it, or use the precompiled firmware from GitHub Actions under that branch. The `ds5-bridge-wake.uf2` is the firmware with this feature enabled.
@@ -80,7 +90,7 @@ https://github.com/zurce/DS5Dongle-OLED
 
 ## Performance / Overclocking
 
-Due to encoding requirements, the Pico2W must be overclocked:
+Due to encoding requirements, the RP2350 must be overclocked:
 
 Current settings:
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
 cmake --build build --target ds5-bridge
 ```
 
+Or download precompiled firmware from GitHub Actions.
+
 ### USB Wake Feature
 
 This feature is experimental. If you need this functionality, please check out the feat/usb-wake branch to compile it,

--- a/boards/build_waveshare_rp2350b_plus_w.sh
+++ b/boards/build_waveshare_rp2350b_plus_w.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Convenience build script for the Waveshare RP2350B-Plus-W target.
+#
+# Requires:
+#   - ARM toolchain (arm-none-eabi-gcc)
+#   - Ninja
+#   - A pico-sdk checkout pinned to 2.2.0 with TinyUSB checked out to 0.20.0.
+#     If you don't already have one, see the README for setup. By default this
+#     script uses PICO_SDK_PATH from the environment.
+#
+# Usage:
+#   ./boards/build_waveshare_rp2350b_plus_w.sh [Release|Debug]   # default: Release
+
+set -euo pipefail
+
+BUILD_TYPE="${1:-Release}"
+BUILD_DIR="build/waveshare"
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [[ -z "${PICO_SDK_PATH:-}" ]]; then
+    echo "PICO_SDK_PATH is not set. Set it to a pico-sdk checkout pinned to 2.2.0+TinyUSB 0.20.0." >&2
+    exit 1
+fi
+
+cd "${PROJECT_ROOT}"
+cmake -S . -B "${BUILD_DIR}" -G Ninja \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DWAVESHARE_RP2350B_PLUS_W_BUILD=ON \
+    -DPICO_SDK_PATH="${PICO_SDK_PATH}"
+cmake --build "${BUILD_DIR}" --target ds5-bridge
+
+echo
+echo "Build complete. UF2 at:"
+echo "  ${PROJECT_ROOT}/${BUILD_DIR}/ds5-bridge.uf2"

--- a/boards/headers/waveshare_rp2350b_plus_w.h
+++ b/boards/headers/waveshare_rp2350b_plus_w.h
@@ -86,24 +86,10 @@ pico_board_cmake_set(PICO_DEFAULT_BOOT_STAGE2, boot2_w25q080)
 #define CYW43_WL_GPIO_LED_PIN 0
 #endif
 
-// If CYW43_WL_GPIO_VBUS_PIN is defined then a CYW43 GPIO has to be used to read VBUS.
-// This can be passed to cyw43_arch_gpio_get to determine if the device is battery powered.
-// PICO_VBUS_PIN and CYW43_WL_GPIO_VBUS_PIN should not both be defined.
-#ifndef CYW43_WL_GPIO_VBUS_PIN
-#define CYW43_WL_GPIO_VBUS_PIN 2
-#endif
-
-// If CYW43_USES_VSYS_PIN is defined then CYW43 uses the VSYS GPIO (defined by PICO_VSYS_PIN) for other purposes.
-// If this is the case, to use the VSYS GPIO it's necessary to ensure CYW43 is not using it.
-// This can be achieved by wrapping the use of the VSYS GPIO in cyw43_thread_enter / cyw43_thread_exit.
-#ifndef CYW43_USES_VSYS_PIN
-#define CYW43_USES_VSYS_PIN 1
-#endif
-
 // The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
 // There is an example in adc/read_vsys in pico-examples.
 #ifndef PICO_VSYS_PIN
-#define PICO_VSYS_PIN 43
+#define PICO_VSYS_PIN 46
 #endif
 
 // pico_cmake_set_default PICO_RP2350_A2_SUPPORTED = 1

--- a/boards/headers/waveshare_rp2350b_plus_w.h
+++ b/boards/headers/waveshare_rp2350b_plus_w.h
@@ -16,6 +16,7 @@
 
 pico_board_cmake_set(PICO_PLATFORM, rp2350)
 pico_board_cmake_set(PICO_CYW43_SUPPORTED, 1)
+pico_board_cmake_set(PICO_DEFAULT_BOOT_STAGE2, boot2_w25q080)
 
 // For board detection
 #define WAVESHARE_RP2350B_PLUS_W

--- a/boards/headers/waveshare_rp2350b_plus_w.h
+++ b/boards/headers/waveshare_rp2350b_plus_w.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2024 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/waveshare_rp2350_plus_w.h"
+
+#ifndef _BOARDS_WAVESHARE_RP2350B_PLUS_W
+#define _BOARDS_WAVESHARE_RP2350B_PLUS_W
+
+pico_board_cmake_set(PICO_PLATFORM, rp2350)
+pico_board_cmake_set(PICO_CYW43_SUPPORTED, 1)
+
+// For board detection
+#define WAVESHARE_RP2350B_PLUS_W
+
+// --- RP2350 VARIANT ---
+#define PICO_RP2350A 0
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (4 * 1024 * 1024)
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
+// note the SMSP mode pin is on WL_GPIO1
+
+#ifndef CYW43_WL_GPIO_COUNT
+#define CYW43_WL_GPIO_COUNT 3
+#endif
+
+#ifndef CYW43_WL_GPIO_LED_PIN
+#define CYW43_WL_GPIO_LED_PIN 0
+#endif
+
+// If CYW43_WL_GPIO_VBUS_PIN is defined then a CYW43 GPIO has to be used to read VBUS.
+// This can be passed to cyw43_arch_gpio_get to determine if the device is battery powered.
+// PICO_VBUS_PIN and CYW43_WL_GPIO_VBUS_PIN should not both be defined.
+#ifndef CYW43_WL_GPIO_VBUS_PIN
+#define CYW43_WL_GPIO_VBUS_PIN 2
+#endif
+
+// If CYW43_USES_VSYS_PIN is defined then CYW43 uses the VSYS GPIO (defined by PICO_VSYS_PIN) for other purposes.
+// If this is the case, to use the VSYS GPIO it's necessary to ensure CYW43 is not using it.
+// This can be achieved by wrapping the use of the VSYS GPIO in cyw43_thread_enter / cyw43_thread_exit.
+#ifndef CYW43_USES_VSYS_PIN
+#define CYW43_USES_VSYS_PIN 1
+#endif
+
+// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
+// There is an example in adc/read_vsys in pico-examples.
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 43
+#endif
+
+// pico_cmake_set_default PICO_RP2350_A2_SUPPORTED = 1
+#ifndef PICO_RP2350_A2_SUPPORTED
+#define PICO_RP2350_A2_SUPPORTED 1
+#endif
+
+// cyw43 SPI pins can't be changed at runtime
+#ifndef CYW43_PIN_WL_DYNAMIC
+#define CYW43_PIN_WL_DYNAMIC 0
+#endif
+
+// gpio pin to power up the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_REG_ON
+#define CYW43_DEFAULT_PIN_WL_REG_ON 36ULL
+#endif
+
+// gpio pin for spi data out to the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_DATA_OUT
+#define CYW43_DEFAULT_PIN_WL_DATA_OUT 37ULL
+#endif
+
+// gpio pin for spi data in from the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_DATA_IN
+#define CYW43_DEFAULT_PIN_WL_DATA_IN 37ULL
+#endif
+
+// gpio (irq) pin for the irq line from the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_HOST_WAKE
+#define CYW43_DEFAULT_PIN_WL_HOST_WAKE 37ULL
+#endif
+
+// gpio pin for the spi clock line to the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_CLOCK
+#define CYW43_DEFAULT_PIN_WL_CLOCK 39ULL
+#endif
+
+// gpio pin for the spi chip select to the cyw43 chip
+#ifndef CYW43_DEFAULT_PIN_WL_CS
+#define CYW43_DEFAULT_PIN_WL_CS 38ULL
+#endif
+
+#endif


### PR DESCRIPTION
## Summary

Adds support for the [Waveshare RP2350B-Plus-W](https://www.waveshare.com/wiki/RP2350B-Plus-W) as a build target. This is an RP2350B-based board with the RM2 wireless module (same CYW43 silicon as the Pico 2 W), 16 MB QSPI flash, and a USB-C connector. Built and tested by the contributor on physical hardware; audio quality matches Pico 2 W on the tested unit.

Builds with:

    cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
          -DPICO_SDK_PATH=<sdk> -DWAVESHARE_RP2350B_PLUS_W_BUILD=ON
    cmake --build build --target ds5-bridge

## Commits in this PR

1. **`build: add Waveshare RP2350B-Plus-W as a build target`** — adds the `WAVESHARE_RP2350B_PLUS_W_BUILD` cmake option and the Waveshare board header (sourced from [Waveshare's official demo zip](https://files.waveshare.com/wiki/RP2350B-Plus-W/RP2350B-Plus-W.zip) on their wiki — BSD-3-Clause, RPi Trading Ltd copyright — shipped in-repo because upstream pico-sdk does not yet include it), plus the supporting `pico_board_cmake_set` boot configuration.

2. **`build: declare boot2_w25q080 as default boot stage 2 for Waveshare`** — sets `PICO_DEFAULT_BOOT_STAGE2=boot2_w25q080` in the board header.

3. **`fix(oc): add PICO_FLASH_SPI_CLKDIV`** — cherry-picked from `dev` branch ([`e5d99f0`](https://github.com/awalol/DS5Dongle/commit/e5d99f0)). Conditionally sets `PICO_FLASH_SPI_CLKDIV=4` for overclocked builds. Required by the final commit to take effect.

4. **`fix(waveshare): correct schematic mismatches in board header`** — three corrections relative to the Waveshare-supplied header values, all verified against the Waveshare schematic PDF:
   - `PICO_VSYS_PIN` 43 → 46 (`VSYS_SENSE` is on GPIO46/ADC6 per schematic; matches arduino-pico variant)
   - `CYW43_WL_GPIO_VBUS_PIN` removed (VBUS detection is on the RP2350 side via Q2 WNM2021-3, not through the RM2/CYW43 module)
   - `CYW43_USES_VSYS_PIN` removed (on this board VSYS sense is GPIO46 and CYW43 WL_CLOCK is GPIO39 — no pin sharing, so the cooperative-access flag is incorrect)

5. **`fix(waveshare): force boot2 execution to fix flash XIP for Puya flash`** — sets `PICO_EMBED_XIP_SETUP=1` for the Waveshare build only. On RP2350, boot stage 2 is NOT executed by default (the bootrom auto-configures XIP from probing the flash chip), so `PICO_FLASH_SPI_CLKDIV` and the boot2 declaration have no runtime effect without this. The Waveshare board ships with a Puya PY25Q128HA flash chip rather than the schematic-listed Winbond W25Q128JVSIQ; the bootrom auto-detected this and configured QMI for `CLKDIV=3` + Fast Read Dual I/O (`0xBB`), which at 320 MHz sys_clk drives flash SPI at 106.7 MHz — over Puya's 104 MHz spec for that read mode at default dummy cycles. The resulting intermittent XIP read corruption manifested as severely choppy audio. Setting `PICO_EMBED_XIP_SETUP=1` forces `boot2_w25q080` to execute, programming CLKDIV=4 (80 MHz flash SPI) and Fast Read Quad I/O (`0xEB`) — matching the Pico 2 W's flash configuration. Verified by reading QMI registers from running firmware and comparing audio against Pico 2 W on the same controller / same source.

6. **`docs(waveshare): document Waveshare RP2350B-Plus-W build target`** — adds a `### Waveshare RP2350B-Plus-W` subsection under Notes with the build command, generalises the tagline/overview/features to mention compatible-board support, and changes "Pico2W" → "RP2350" in the Performance / Overclocking section (the overclock parameters apply at the chip level).

## What's tested

- [x] Waveshare RP2350B-Plus-W: boots, pairs DualSense over BT, controller input forwarded, audio sounds clean and matches Pico 2 W
- [x] Pico 2 W regression: builds cleanly with `-DPICO_W_BUILD=OFF -DWAVESHARE_RP2350B_PLUS_W_BUILD=OFF` (default), the new conditional logic correctly excludes Pico 2 W from getting `PICO_EMBED_XIP_SETUP=1`, audio still sounds clean on Pico 2 W reference
- [x] Listening tests done with the same DualSense, same source material, same Windows host across both boards

## What's NOT tested

- Long-session stability not characterised
- One Waveshare board sample — other production units may ship with a different flash chip than the Puya I have. The fix should be robust to either Winbond or Puya since `boot2_w25q080` is compatible with both at the QE/continuous-read level
- Battery-LED behaviour (was using a USB-powered desktop test rig)

## Preview release

A pre-release for community testing: https://github.com/up2urheadlights/DS5Dongle/releases/tag/waveshare-test-4

## Related

- References #12 (clone-board discussion thread — should remain open for other RP2350 board efforts)
- Cherry-picks from `dev` branch commit e5d99f0
- References pico-sdk issue [#1903](https://github.com/raspberrypi/pico-sdk/issues/1903) (RP2350 boot stage 2 not run by default)