### PR TITLE
fix(bt): restart inquiry and LED blink on disconnect

### DIFF
--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -379,7 +379,8 @@ static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
             battery_led_on_disconnect();
 #endif
             printf("[HCI] Disconnected reason=0x%02X\n", reason);
-            // gap_inquiry_start(30);
+            gap_inquiry_start(30);
+            bt_inquiring = true;
             break;
         }
 


### PR DESCRIPTION
After bb61e00 ("fix: led blink after connected") the disconnect handler in 
src/bt.cpp no longer calls gap_inquiry_start(30), and the new bt_inquiring 
flag is never set back to true. This produces two regressions visible on 
disconnect (controller powered off or out of range):

1. **Functional:** After the controller disconnects, the dongle stops 
   actively scanning for new controllers. `gap_connectable_control(1)` and 
   `gap_discoverable_control(1)` remain enabled, so previously-paired 
   controllers can still initiate reconnection in some cases, but the 
   inquiry-based discovery path is broken. A freshly-unpaired controller 
   or a different DualSense cannot be discovered.

2. **Visual:** The `bt_inquiring_led()` blink function returns early when 
   `bt_inquiring` is false, so the LED stays solid-off after disconnect 
   regardless of whether the dongle should be actively looking for a 
   controller.

The fix re-adds the inquiry restart and sets the flag in 
`HCI_EVENT_DISCONNECTION_COMPLETE`:

    gap_inquiry_start(30);
    bt_inquiring = true;

## Testing

Tested on Pico 2 W with ARM official GCC 14.2.Rel1:
- **Before:** controller power-off → LED stays off, controller cannot 
  re-pair, fresh controller cannot pair
- **After:** controller power-off → LED resumes blinking, controller 
  re-pairs cleanly on PS button, fresh controller discoverable