### PR TITLE
refactor(cmd): set pico settings by 0x80 report

### DIFF
--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -600,12 +600,17 @@ void __not_in_flash_func(bt_write)(const uint8_t *data, const uint16_t len) {
 vector<uint8_t> get_feature_data(uint8_t reportId, uint16_t len) {
     // 若为0x81则会请求新内容，其他若有旧数据则不进行请求
     auto ret = vector<uint8_t>{};
-    if (feature_data.contains(reportId)) {
+    const bool has_cached_report = feature_data.contains(reportId);
+    if (has_cached_report) {
         ret = feature_data[reportId];
     }
-    if (!feature_data.contains(reportId) ||
+    const bool use_pico_cmd_response =
+        reportId == 0x81 &&
+        ret.size() >= 2 &&
+        ret[0] == 0x66;
+    if (!has_cached_report ||
         // Get Test Command Result
-        reportId == 0x81 ||
+        (reportId == 0x81 && !use_pico_cmd_response) ||
         // DSE: Set Profile Save?
         reportId == 0x63 ||
         reportId == 0x65 ||
@@ -621,6 +626,9 @@ vector<uint8_t> get_feature_data(uint8_t reportId, uint16_t len) {
             printf("[L2CAP] Requesting Get Feature Report 0x%02X\n", reportId);
 #endif
         }
+    }
+    if (use_pico_cmd_response) {
+        feature_data.erase(reportId);
     }
     return ret;
 }

--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -160,10 +160,9 @@ void pico_cmd_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize) {
                 }
             }
             uint8_t buf[63]{};
-            buf[0] = 0x81;
-            buf[1] = 0x66;
-            buf[2] = 0x01;
-            buf[3] = success ? 0x00 : 0x01;
+            buf[0] = 0x66;
+            buf[1] = 0x01;
+            buf[2] = success ? 0x00 : 0x01;
             feature_data[0x81].assign(buf, buf + sizeof(buf));
             break;
         }
@@ -185,7 +184,7 @@ void pico_cmd_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize) {
             buf[0] = 0x66;
             buf[1] = 0x04;
             memcpy(buf + 2, &get_config(), sizeof(Config_body));
-            feature_data[0x81].assign(buf,buf + sizeof(buf));
+            feature_data[0x81].assign(buf, buf + sizeof(buf));
             break;
         }
         case 0x05: {

--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <unordered_map>
 
 #include "bt.h"
 #include "config.h"
@@ -18,6 +19,7 @@
 // 0xf9 feature report so the config UI can display the real gated mic/speaker
 // state, reflecting the disable_mic / disable_speaker settings.
 extern bool spk_active;
+extern std::unordered_map<uint8_t, std::vector<uint8_t> > feature_data;
 
 bool is_pico_cmd(uint8_t report_id) {
     if (report_id == 0xf6 ||
@@ -36,8 +38,8 @@ uint16_t pico_cmd_get(uint8_t report_id, uint8_t *buffer, uint16_t reqlen) {
         if (sizeof(Config_body) > reqlen) {
             printf("[Config] Warning: Config_body overflow\n");
         }
-        const auto len = std::min(sizeof(Config_body),static_cast<size_t>(reqlen));
-        memcpy(buffer,&get_config(),len);
+        const auto len = std::min(sizeof(Config_body), static_cast<size_t>(reqlen));
+        memcpy(buffer, &get_config(), len);
         return len;
     }
     if (report_id == 0xf8) {
@@ -73,8 +75,7 @@ uint16_t pico_cmd_get(uint8_t report_id, uint8_t *buffer, uint16_t reqlen) {
     return 0;
 }
 
-void pico_cmd_set(uint8_t report_id, uint8_t const *buffer, uint16_t bufsize) {
-    (void) report_id;
+void pico_cmd_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize) {
     if (bufsize == 0) {
         return;
     }
@@ -82,20 +83,35 @@ void pico_cmd_set(uint8_t report_id, uint8_t const *buffer, uint16_t bufsize) {
     // 0x01 update config in variable
     // 0x02 write config to flash
     // 0x03 reconnect tinyusb device;
-    if (buffer[0] == 0x01) {
+
+    switch (cmd_id) {
+        case 0x01: {
 #if ENABLE_VERBOSE
-        printf("[CMD] Enter config set func\n");
+            printf("[CMD] Enter config set func\n");
 #endif
-        set_config(buffer + 1, bufsize - 1);
-    }
-    if (buffer[0] == 0x02) {
-        printf("[CMD] Enter config save func\n");
-        config_save();
-    }
-    if (buffer[0] == 0x03) {
-        printf("[CMD] Enter tud reconnect func\n");
-        tud_disconnect();
-        sleep_ms(150);
-        tud_connect();
+            set_config(buffer, bufsize);
+            break;
+        }
+        case 0x02: {
+            printf("[CMD] Enter config save func\n");
+            config_save();
+            break;
+        }
+        case 0x03: {
+            printf("[CMD] Enter tud reconnect func\n");
+            tud_disconnect();
+            sleep_ms(150);
+            tud_connect();
+            break;
+        }
+        case 0x04: {
+            printf("[CMD] get config\n");
+            uint8_t buf[63]{};
+            buf[0] = 0x66;
+            buf[1] = 0x04;
+            memcpy(buf + 2, &get_config(), sizeof(Config_body));
+            feature_data[0x81].assign(buf,buf + sizeof(buf));
+            break;
+        }
     }
 }

--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -16,71 +16,131 @@
 #include "audio.h"
 
 // spk_active (main.cpp) + audio_mic_active() (audio.cpp) are surfaced in the
-// 0xf9 feature report so the config UI can display the real gated mic/speaker
+// 0xf9 command response so the config UI can display the real gated mic/speaker
 // state, reflecting the disable_mic / disable_speaker settings.
 extern bool spk_active;
 extern std::unordered_map<uint8_t, std::vector<uint8_t> > feature_data;
 
-bool is_pico_cmd(uint8_t report_id) {
-    if (report_id == 0xf6 ||
-        report_id == 0xf7 ||
-        report_id == 0xf8 ||
-        report_id == 0xf9
-    ) {
-        return true;
+template<typename T>
+static bool read_config_value(T &value, uint8_t const *buffer, uint16_t bufsize) {
+    if (bufsize < sizeof(T)) {
+        return false;
     }
-    return false;
+    memcpy(&value, buffer, sizeof(T));
+    return true;
 }
 
-uint16_t pico_cmd_get(uint8_t report_id, uint8_t *buffer, uint16_t reqlen) {
-    if (report_id == 0xf7) {
-        printf("[HID] Receive 0xf7 getting config\n");
-        if (sizeof(Config_body) > reqlen) {
-            printf("[Config] Warning: Config_body overflow\n");
+static bool set_config_field(uint8_t field_id, uint8_t const *buffer, uint16_t bufsize) {
+    Config_body new_config = get_config();
+
+    switch (field_id) {
+        case 0x01: {
+            float value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.haptics_gain = value;
+            break;
         }
-        const auto len = std::min(sizeof(Config_body), static_cast<size_t>(reqlen));
-        memcpy(buffer, &get_config(), len);
-        return len;
-    }
-    if (report_id == 0xf8) {
-        printf("[HID] Receive 0xf8 getting firmware version\n");
-        const auto len = std::min(strlen(PICO_PROGRAM_VERSION_STRING), static_cast<size_t>(reqlen));
-        memcpy(buffer, PICO_PROGRAM_VERSION_STRING, len);
-        return len;
-    }
-    if (report_id == 0xf9) {
-        // [-128,0]
-        int8_t rssi = 0;
-        bt_get_signal_strength(&rssi);
-        if (reqlen == 0) {
-            return 0;
+        case 0x02: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.speaker_volume = value;
+            break;
         }
-        buffer[0] = rssi;
-        // byte 1: real audio gating state, for the config UI to display.
-        //   bit7 = valid marker (firmware without this byte leaves it 0)
-        //   bit0 = controller mic actually streaming (host opened it AND !disable_mic)
-        //   bit1 = controller speaker actually driven (host opened it AND !disable_speaker)
-        if (reqlen >= 2) {
-            uint8_t flags = 0x80;
-            if (audio_mic_active() && !get_config().disable_mic) flags |= 0x01;
-            if (spk_active && !get_config().disable_speaker) flags |= 0x02;
-            buffer[1] = flags;
-            return 2;
+        case 0x03: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.headset_volume = value;
+            break;
         }
-#if ENABLE_VERBOSE
-        printf("[HID] 0xf9 RSSI=%d raw=0x%02X\n", rssi, buffer[0]);
-#endif
-        return 1;
+        case 0x04: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.sync_spk_headset_volume = value;
+            break;
+        }
+        case 0x05: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.speaker_gain = value;
+            break;
+        }
+        case 0x06: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.inactive_time = value;
+            break;
+        }
+        case 0x07: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.disable_inactive_disconnect = value;
+            break;
+        }
+        case 0x08: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.disable_pico_led = value;
+            break;
+        }
+        case 0x09: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.polling_rate_mode = value;
+            break;
+        }
+        case 0x0a: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.audio_buffer_length = value;
+            break;
+        }
+        case 0x0b: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.controller_mode = value;
+            break;
+        }
+        case 0x0c: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.lock_volume = value;
+            break;
+        }
+        case 0x0d: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.disable_usb_sn = value;
+            break;
+        }
+        case 0x0e: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.ps_shortcut_enabled = value;
+            break;
+        }
+        case 0x0f: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.disable_mic = value;
+            break;
+        }
+        case 0x10: {
+            uint8_t value{};
+            if (!read_config_value(value, buffer, bufsize)) return false;
+            new_config.disable_speaker = value;
+            break;
+        }
+        default:
+            printf("[CMD] Unknown config field id: 0x%02X\n", field_id);
+            return false;
     }
-    return 0;
+
+    set_config(reinterpret_cast<const uint8_t *>(&new_config), sizeof(new_config));
+    return true;
 }
 
 void pico_cmd_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize) {
-    if (bufsize == 0) {
-        return;
-    }
-
-    // 0x01 update config in variable
+    // 0x01 update config field in variable: field_id + typed value
     // 0x02 write config to flash
     // 0x03 reconnect tinyusb device;
 
@@ -89,7 +149,22 @@ void pico_cmd_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize) {
 #if ENABLE_VERBOSE
             printf("[CMD] Enter config set func\n");
 #endif
-            set_config(buffer, bufsize);
+            bool success = false;
+            if (bufsize < 1) {
+                printf("[CMD] Config set missing field id\n");
+            } else {
+                const uint8_t field_id = buffer[0];
+                success = set_config_field(field_id, buffer + 1, bufsize - 1);
+                if (!success) {
+                    printf("[CMD] Config set failed, field id: 0x%02X\n", field_id);
+                }
+            }
+            uint8_t buf[63]{};
+            buf[0] = 0x81;
+            buf[1] = 0x66;
+            buf[2] = 0x01;
+            buf[3] = success ? 0x00 : 0x01;
+            feature_data[0x81].assign(buf, buf + sizeof(buf));
             break;
         }
         case 0x02: {
@@ -111,6 +186,36 @@ void pico_cmd_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize) {
             buf[1] = 0x04;
             memcpy(buf + 2, &get_config(), sizeof(Config_body));
             feature_data[0x81].assign(buf,buf + sizeof(buf));
+            break;
+        }
+        case 0x05: {
+            printf("[CMD] get firmware version\n");
+            uint8_t buf[63]{};
+            buf[0] = 0x66;
+            buf[1] = 0x05;
+            const auto len = std::min(strlen(PICO_PROGRAM_VERSION_STRING), sizeof(buf) - 2);
+            memcpy(buf + 2, PICO_PROGRAM_VERSION_STRING, len);
+            feature_data[0x81].assign(buf, buf + sizeof(buf));
+            break;
+        }
+        case 0x06: {
+            printf("[CMD] get signal strength\n");
+            uint8_t buf[63]{};
+            buf[0] = 0x66;
+            buf[1] = 0x06;
+            // [-128,0]
+            int8_t rssi = 0;
+            bt_get_signal_strength(&rssi);
+            buf[2] = rssi;
+            // byte 3: real audio gating state, for the config UI to display.
+            //   bit7 = valid marker
+            //   bit0 = controller mic actually streaming (host opened it AND !disable_mic)
+            //   bit1 = controller speaker actually driven (host opened it AND !disable_speaker)
+            uint8_t flags = 0x80;
+            if (audio_mic_active() && !get_config().disable_mic) flags |= 0x01;
+            if (spk_active && !get_config().disable_speaker) flags |= 0x02;
+            buf[3] = flags;
+            feature_data[0x81].assign(buf, buf + sizeof(buf));
             break;
         }
     }

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -7,8 +7,6 @@
 
 #include <stdint.h>
 
-bool is_pico_cmd(uint8_t report_id);
-uint16_t pico_cmd_get(uint8_t report_id, uint8_t *buffer,uint16_t reqlen);
 void pico_cmd_set(uint8_t report_id, uint8_t const *buffer,uint16_t bufsize);
 
 #endif //DS5_BRIDGE_CMD_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,6 +164,10 @@ uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t
 
     std::vector<uint8_t> feature_data = get_feature_data(report_id, reqlen);
     if (!feature_data.empty()) {
+        if (report_id == 0x81 && feature_data[0] == 0x66) {
+            memcpy(buffer, feature_data.data(), feature_data.size());
+            return feature_data.size();
+        }
         memcpy(buffer, feature_data.data() + 1, feature_data.size() - 1);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,13 +225,13 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
             }
         }
     }
-    if (report_id == 0x80 && buffer[0] == 0x66) {
+    if (report_id == 0x80 && bufsize >= 2 && buffer[0] == 0x66) {
 #if ENABLE_VERBOSE
         printf("[HID] Receive 0x66 setting config, funcid:0x%02X\n", buffer[1]);
 #endif
 
-        // 0x80 0x66 cmd_id buffer...
-        pico_cmd_set(buffer[1], buffer + 1, bufsize - 2);
+        // 0x80 0x66 cmd_id payload...
+        pico_cmd_set(buffer[1], buffer + 2, bufsize - 2);
         return;
     }
     if (report_id == 0x80 ||

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,10 +154,6 @@ uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t
     (void) buffer;
     (void) reqlen;
 
-    if (is_pico_cmd(report_id)) {
-        return pico_cmd_get(report_id, buffer, reqlen);
-    }
-
     // DSE profiles: while the unlock + prefetch is still in progress, return 0
     // (NAK) for profile reads so the PS app retries rather than caching an
     // empty snapshot. Still kick off the background BT fetch.
@@ -207,14 +203,6 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
     (void) buffer;
     (void) bufsize;
 
-    if (is_pico_cmd(report_id)) {
-#if ENABLE_VERBOSE
-        printf("[HID] Receive 0xf6 setting config, funcid:0x%02X\n", buffer[0]);
-#endif
-        pico_cmd_set(report_id, buffer, bufsize);
-        return;
-    }
-
     // INTERRUPT OUT
     if (report_id == 0) {
         switch (buffer[0]) {
@@ -237,13 +225,21 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
             }
         }
     }
+    if (report_id == 0x80 && buffer[0] == 0x66) {
+#if ENABLE_VERBOSE
+        printf("[HID] Receive 0x66 setting config, funcid:0x%02X\n", buffer[1]);
+#endif
+
+        // 0x80 0x66 cmd_id buffer...
+        pico_cmd_set(buffer[1], buffer + 1, bufsize - 2);
+        return;
+    }
     if (report_id == 0x80 ||
         // DSE: Write Profile Block
         report_id == 0x60 ||
         report_id == 0x62 ||
         report_id == 0x61) {
         set_feature_data(report_id, const_cast<uint8_t *>(buffer), bufsize);
-        return;
     }
 }
 

--- a/src/usb_descriptors.cpp
+++ b/src/usb_descriptors.cpp
@@ -382,8 +382,8 @@ uint8_t descriptor_configuration[] = {
     0x00, // bCountryCode: Not localized
     0x01, // bNumDescriptors: 1 report descriptor
     0x22, // bDescriptorType: Report
-    0x41, 0x01, // wDescriptorLength: 321 (0x0141) DS
-    // 0xB5, 0x01, // wDescriptorLength: 437 (0x01B5) DSE
+    0x21, 0x01, // wDescriptorLength: 289 (0x0121) DS
+    // 0x95, 0x01, // wDescriptorLength: 405 (0x0195) DSE
 
     // Endpoint Descriptor (HID IN: EP4)
     0x07, // bLength
@@ -459,9 +459,9 @@ uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
     descriptor_configuration[offset - 1] = bInterval;
     descriptor_configuration[offset - 8] = bInterval;
     if (ds_mode()) {
-        descriptor_configuration[offset - 16] = 0x41;
+        descriptor_configuration[offset - 16] = 0x21;
     }else {
-        descriptor_configuration[offset - 16] = 0xB5;
+        descriptor_configuration[offset - 16] = 0x95;
     }
     return descriptor_configuration;
 }
@@ -612,26 +612,11 @@ uint8_t const desc_hid_report_ds[] = {
     0x09, 0x36, //   Usage (0x36)
     0x95, 0x03, //   Report Count (3)
     0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
-    0x85, 0xF6, //   Report ID (-10)
-    0x09, 0x37, //   Usage (Vendor 0x37)
-    0x95, 0x3F, //   Report Count (63)
-    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
-    0x85, 0xF7, //   Report ID (-9)
-    0x09, 0x38, //   Usage (Vendor 0x38)
-    0x95, 0x3F, //   Report Count (63)
-    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
-    0x85, 0xF8, //   Report ID (-8)
-    0x09, 0x39, //   Usage (Vendor 0x39)
-    0x95, 0x3F, //   Report Count (63)
-    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
-    0x85, 0xF9, //   Report ID (-7)
-    0x09, 0x3A, //   Usage (Vendor 0x3A)
-    0x95, 0x3F, //   Report Count (63)
-    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
     0xC0, // End Collection
-    // 321 bytes
+
+    // 289 bytes
 };
-static_assert(sizeof(desc_hid_report_ds) == 0x0141);
+static_assert(sizeof(desc_hid_report_ds) == 289);
 
 uint8_t const desc_hid_report_dse[] = {
     0x05, 0x01, // Usage Page (Generic Desktop Ctrls)
@@ -833,26 +818,10 @@ uint8_t const desc_hid_report_dse[] = {
     0x85, 0x7B, //   Report ID (123)
     0x09, 0x53, //   Usage (0x53)
     0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
-    0x85, 0xF6, //   Report ID (-10)
-    0x09, 0x37, //   Usage (Vendor 0x37)
-    0x95, 0x3F, //   Report Count (63)
-    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
-    0x85, 0xF7, //   Report ID (-9)
-    0x09, 0x38, //   Usage (Vendor 0x38)
-    0x95, 0x3F, //   Report Count (63)
-    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
-    0x85, 0xF8, //   Report ID (-8)
-    0x09, 0x39, //   Usage (Vendor 0x39)
-    0x95, 0x3F, //   Report Count (63)
-    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
-    0x85, 0xF9, //   Report ID (-7)
-    0x09, 0x3A, //   Usage (Vendor 0x3A)
-    0x95, 0x3F, //   Report Count (63)
-    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
     0xC0, // End Collection
-    // 437 bytes
+    // 405 bytes
 };
-static_assert(sizeof(desc_hid_report_dse) == 0x01B5);
+static_assert(sizeof(desc_hid_report_dse) == 405);
 
 #ifdef ENABLE_WAKE_HID
 // 41-byte boot-keyboard report descriptor (modifier byte + reserved + 6 keycodes,


### PR DESCRIPTION
maybe #154 solved？

- Revert the HID report descriptor to match a standard DS5.
> Issue #154 may be caused by the modified HID report descriptor preventing games from sending vibration commands.

- Use the 0x80 report to modify Pico settings.
> Change the settings by field_id per setting to ensure compatibility across different versions of the web configurator.