### PR TITLE
Passive reconnect: inquire only when discovering a controller (revert #150 inquiry-on-disconnect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ controllers and resets the dongle — no unplugging or re-flashing needed:
   current connection and recovers from a transient glitch. It re-enters pairing
   inquiry **only if no controller is paired**; with a controller already in memory
   it boots quietly and waits for that controller to reconnect on its own (no
-  inquiry, no LED blink). (Clicks register after a brief pause, to allow for a
-  second/third click.)
+  inquiry, no LED blink).
 - **Triple click:** **Reboot into BOOTSEL** — the dongle re-enumerates as a USB
   mass-storage drive so you can drag on a new `.uf2`, without holding BOOTSEL while
   plugging in.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ You have two options:
 
 ***You may need to replug the Pico when the controller is in pairing mode.***
 
+Once a controller has been paired, the dongle reconnects to it **silently**: it
+stays in Bluetooth page scan, and the controller links back on its own when you
+turn it on (press **PS**) — no inquiry, and the onboard LED stays dark. The dongle
+only runs a discovery scan (with the LED blinking) when **no controller is paired**,
+or when you explicitly start one with a BOOTSEL **single click**. A power-off, idle
+timeout, sleep, restart, or dongle reboot therefore no longer kicks off a
+30-second pairing scan the way it used to.
+
 ### BOOTSEL button: switch, reboot, or clear controllers
 
 While the firmware is running, the Pico's **BOOTSEL button** doubles as a
@@ -62,16 +70,20 @@ controller and reset control — no unplugging or re-flashing needed:
   - If nothing is connected, a 30-second scan starts to pair a new controller.
     Put the DualSense into pairing mode (hold **PS + Create/Share** until the
     light bar flashes) while the scan runs.
-- **Double click:** **Reboot the Pico** — a normal firmware restart: re-enters
-  pairing inquiry, drops the current connection, and recovers from a transient
-  glitch. (Clicks register after a brief pause, to allow for a second/third click.)
+- **Double click:** **Reboot the Pico** — a normal firmware restart that drops the
+  current connection and recovers from a transient glitch. It re-enters pairing
+  inquiry **only if no controller is paired**; with a controller already in memory
+  it boots quietly and waits for that controller to reconnect on its own (no
+  inquiry, no LED blink). (Clicks register after a brief pause, to allow for a
+  second/third click.)
 - **Triple click:** **Reboot into BOOTSEL** — the dongle re-enumerates as a USB
   mass-storage drive so you can drag on a new `.uf2`, without holding BOOTSEL while
   plugging in.
 - **Long press (~1.5 s):** Disconnect and **forget every paired controller** — all
   stored pairings are deleted and blacklisted so they won't silently auto-reconnect,
-  even across a power cycle. The onboard LED flashes six times to confirm. To use a
-  forgotten controller again, put it back into **PS + Create/Share** pairing mode.
+  even across a power cycle. The onboard LED flashes six times to confirm. To pair a
+  controller again, start a scan with a **single click** (or replug the dongle) and
+  put it into **PS + Create/Share** pairing mode.
 
 > Triple click is a software path into the bootloader; you can also still enter it
 > the hardware way by holding BOOTSEL **while plugging in** the Pico (see

--- a/README.md
+++ b/README.md
@@ -64,12 +64,11 @@ While the firmware is running, the Pico's **BOOTSEL button** also manages paired
 controllers and resets the dongle — no unplugging or re-flashing needed:
 
 - **Short press (click):**
-  - If a controller is connected, the current one is disconnected (its pairing is
-    kept, so it can reconnect later). Use this to free the dongle to pair a
-    previously unknown controller.
-  - If nothing is connected, a 30-second scan starts to pair a new controller.
-    Put the DualSense into pairing mode (hold **PS + Create/Share** until the
-    light bar flashes) while the scan runs.
+  - **While a controller is connected** — disconnects it (pairing kept). The
+    dongle goes quiet and stays connectable, so a different already-paired
+    controller can take over.
+  - **While nothing is connected** — starts a 30-second pairing scan (put the new
+    controller into **PS + Create/Share** mode while the LED blinks).
 - **Double click:** **Reboot the Pico** — a normal firmware restart that drops the
   current connection and recovers from a transient glitch. It re-enters pairing
   inquiry **only if no controller is paired**; with a controller already in memory

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ timeout, sleep, restart, or dongle reboot therefore no longer kicks off a
 
 ### BOOTSEL button: switch, reboot, or clear controllers
 
-While the firmware is running, the Pico's **BOOTSEL button** doubles as a
-controller and reset control — no unplugging or re-flashing needed:
+While the firmware is running, the Pico's **BOOTSEL button** also manages paired
+controllers and resets the dongle — no unplugging or re-flashing needed:
 
 - **Short press (click):**
   - If a controller is connected, the current one is disconnected (its pairing is
-    kept, so it can reconnect later). Use this to free the dongle for a different
-    already-paired controller.
+    kept, so it can reconnect later). Use this to free the dongle to pair a
+    previously unknown controller.
   - If nothing is connected, a 30-second scan starts to pair a new controller.
     Put the DualSense into pairing mode (hold **PS + Create/Share** until the
     light bar flashes) while the scan runs.

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -355,10 +355,7 @@ void bt_inquiring_led() {
     }
 }
 
-// True if BTstack already has a stored controller link key. When we know a
-// controller we skip the boot inquiry and just wait on page scan -- a paired
-// controller reconnects on its own (gap_connectable_control). No stored key
-// (fresh dongle, or after a BOOTSEL-hold clear-all) -> inquire to pair one.
+// True if BTstack has at least one stored controller link key.
 static bool bt_has_stored_link_key() {
     btstack_link_key_iterator_t it;
     if (!gap_link_key_iterator_init(&it)) return false;
@@ -381,11 +378,8 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             printf("[BT] State: %u\n", state);
             if (state == HCI_STATE_WORKING) {
                 bt_blacklist_load();
-                // Only inquire on boot when we don't already know a controller.
-                // With a stored link key, the paired controller reconnects on its
-                // own via page scan, so stay dark and skip the inquiry blink. Pair
-                // a different controller with the BOOTSEL single-click; a clear-all
-                // (BOOTSEL hold) wipes the keys so the next boot scans again.
+                // Only inquire on boot when no controller is paired; a stored
+                // controller reconnects on its own via page scan.
                 if (bt_has_stored_link_key()) {
                     printf("[BT] Stack ready, stored controller -> page scan, no inquiry\n");
                 } else {
@@ -629,12 +623,9 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             battery_led_on_disconnect();
 #endif
             printf("[HCI] Disconnected reason=0x%02X\n", reason);
-            // Reverts #150: do NOT auto-restart inquiry on disconnect. Page scan
-            // stays enabled (gap_connectable_control above), so a previously-paired
-            // controller reconnects on its own when powered back on. Discovering a
-            // *different* controller is an explicit action (BOOTSEL single-click).
-            // This keeps the LED dark after every power-off / sleep / timeout
-            // instead of blinking the 30 s inquiry.
+            // No inquiry on disconnect: page scan (above) handles reconnect of a
+            // paired controller; discovering a new one is the explicit BOOTSEL
+            // single-click.
             bt_inquiring = false;
             break;
         }

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -355,6 +355,21 @@ void bt_inquiring_led() {
     }
 }
 
+// True if BTstack already has a stored controller link key. When we know a
+// controller we skip the boot inquiry and just wait on page scan -- a paired
+// controller reconnects on its own (gap_connectable_control). No stored key
+// (fresh dongle, or after a BOOTSEL-hold clear-all) -> inquire to pair one.
+static bool bt_has_stored_link_key() {
+    btstack_link_key_iterator_t it;
+    if (!gap_link_key_iterator_init(&it)) return false;
+    bd_addr_t addr;
+    link_key_t key;
+    link_key_type_t type;
+    const bool has_key = gap_link_key_iterator_get_next(&it, addr, key, &type);
+    gap_link_key_iterator_done(&it);
+    return has_key;
+}
+
 static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size) {
     (void) channel;
 
@@ -365,10 +380,19 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             const uint8_t state = btstack_event_state_get_state(packet);
             printf("[BT] State: %u\n", state);
             if (state == HCI_STATE_WORKING) {
-                printf("[BT] Stack ready, start inquiry\n");
                 bt_blacklist_load();
-                gap_inquiry_start(30);
-                bt_inquiring = true;
+                // Only inquire on boot when we don't already know a controller.
+                // With a stored link key, the paired controller reconnects on its
+                // own via page scan, so stay dark and skip the inquiry blink. Pair
+                // a different controller with the BOOTSEL single-click; a clear-all
+                // (BOOTSEL hold) wipes the keys so the next boot scans again.
+                if (bt_has_stored_link_key()) {
+                    printf("[BT] Stack ready, stored controller -> page scan, no inquiry\n");
+                } else {
+                    printf("[BT] Stack ready, no stored controller -> start inquiry\n");
+                    gap_inquiry_start(30);
+                    bt_inquiring = true;
+                }
             }
             break;
         }

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -605,8 +605,13 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             battery_led_on_disconnect();
 #endif
             printf("[HCI] Disconnected reason=0x%02X\n", reason);
-            gap_inquiry_start(30);
-            bt_inquiring = true;
+            // Reverts #150: do NOT auto-restart inquiry on disconnect. Page scan
+            // stays enabled (gap_connectable_control above), so a previously-paired
+            // controller reconnects on its own when powered back on. Discovering a
+            // *different* controller is an explicit action (BOOTSEL single-click).
+            // This keeps the LED dark after every power-off / sleep / timeout
+            // instead of blinking the 30 s inquiry.
+            bt_inquiring = false;
             break;
         }
 


### PR DESCRIPTION
## Summary

The dongle runs a 30-second Bluetooth **inquiry** (active discovery scan) far more
than it needs to — on every disconnect (#150) and on every boot — even when it
already knows the controller. Inquiry blinks the onboard LED and, more importantly,
competes with the **page scan** a paired controller uses to reconnect.

This PR makes the dongle **inquire only when it actually needs to discover a
controller**: when none is paired, or on an explicit BOOTSEL single-click. A
previously-paired controller reconnects on its own via page scan, silently. This is
the model described in #162 — *"the Pico should not be scanning; the controller
should initiate the reconnection by itself."*

## Changes

**1. Stop auto-restarting inquiry on disconnect — reverts #150**
`HCI_EVENT_DISCONNECTION_COMPLETE` no longer calls `gap_inquiry_start(30)`. Page
scan (`gap_connectable_control`, already enabled there) handles reconnection of a
paired controller; discovering a *different* one is the explicit BOOTSEL single
click. #150 had re-added the inquiry to restore new-controller discovery, but its
side effect is a 30 s LED blink — and page-scan starvation — after *every* drop.
This keeps that goal (single-click still inquires) without the cost.

**2. Skip the boot inquiry when a controller is already paired**
On `HCI_STATE_WORKING`, check for a stored link key (via the existing
`gap_link_key_iterator`). Known controller → boot straight into page scan (dark, no
inquiry) and let it reconnect; only inquire on boot when nothing is paired (fresh
dongle / after a clear-all).

Plus README updates to match (BOOTSEL button section, reconnect behaviour, single
click).

## User-visible behaviour

- A paired controller that powers off, idle-times-out, or drops out of range now
  **reconnects silently** when you turn it back on — no LED blink, no 30 s scan.
- **Sleeping, shutting down, or restarting the host** no longer leaves the dongle
  blinking a 30 s scan. The controller powers off on USB suspend (dropping the
  link), and that disconnect is now silent like any other — fixing the
  "LED keeps flashing after I sleep my PC" complaint.
- The dongle **boots dark** when it already knows a controller, instead of running
  a pairing scan.
- Pairing a **new / different** controller is the BOOTSEL **single click**
  (explicit discovery scan) — unchanged.
- A **clear-all** (BOOTSEL hold) still wipes pairings; single-click (or replug) to
  pair fresh.

## Likely addresses #162 (reconnect delay)

#162 reports occasional ~10–15 s reconnect delays. The probable cause is the
**~38 s active inquiry** (`gap_inquiry_start(30)` — BTstack's argument is in 1.28 s
units) fired on every disconnect/boot: active inquiry monopolises the single radio
and starves the page scan a reconnecting controller relies on, so its page only
squeezes through somewhere in that window (≈ the reported delay), and in the tail it
times out and the controller powers off. Removing the inquiry frees the radio for
page scan. Cleanly A/B-testable by #162 reporters (this branch vs master). Note
PR #82 ("reduce idle scan rate") went the *opposite* direction — it would worsen
reconnect — and is unmerged, so it is not the cause.

## Testing

Built for `pico2_w` at the stock 150 MHz. Verified on hardware:
- Power-off → PS-press reconnect, idle-timeout → reconnect, out-of-range →
  reconnect: all reconnect cleanly on page scan alone, LED stays dark throughout.
- Boot with a paired controller: dark, reconnects; boot with none: inquires.
- Single-click while connected turns the controller off (stays off until PS);
  single-click while idle starts a pairing scan.

Diff is small and focused: `src/bt.cpp` plus README.
