### PR TITLE
Leave the light bar to the controller's own default (don't paint a fixed colour on connect)

### DIFF
--- a/src/state_mgr.cpp
+++ b/src/state_mgr.cpp
@@ -39,6 +39,13 @@ void state_init() {
     state.VolumeHeadphones = get_config().headset_volume;
     set_volume(get_config().speaker_volume,get_config().headset_volume);
     set_gain(get_config().speaker_gain);
+
+    // Deliberately leave the light bar to the controller's own default: clear
+    // the colour/fade/brightness flags so the connect report doesn't claim the
+    // RGB strip.
+    state.AllowLedColor = 0;
+    state.AllowColorLightFadeAnimation = 0;
+    state.AllowLightBrightnessChange = 0;
 }
 
 void state_set(uint8_t *data, const uint8_t size) {


### PR DESCRIPTION
## Summary

On connect the firmware paints the DualSense light bar a fixed colour (the gold
default baked into `state_init_data`). This PR clears the light-bar control valid
flags in `state_init` so the connect report no longer claims the RGB strip — the
controller keeps its own Bluetooth default (blue).

## Why

The fixed colour reads like a status indicator it isn't. In particular the
DualSense's own amber/orange pulse is its *charging* indicator, so a fixed
amber/gold on a fully-connected pad is easy to misread. Leaving the strip to the
controller gives its familiar default (blue over Bluetooth), and the host (Steam /
a game) can still drive the light bar afterward exactly as before.

## Change

Clear `AllowLedColor`, `AllowColorLightFadeAnimation`, and
`AllowLightBrightnessChange` in `state_init`, so the connect report hands the RGB
strip back to the controller's own firmware. `state_init_data` is otherwise
unchanged — the colour bytes are simply no longer applied.

## Testing

Built for `pico2_w` at the stock 150 MHz. On hardware the light bar shows the
controller's own blue default on connect instead of the fixed colour; host-driven
lighting (Steam / games) is unaffected.

Diff: `src/state_mgr.cpp` (+7).
