### PR TITLE
Wake, WebHID config, post-game lights, and passive reconnect fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ controllers and resets the dongle — no unplugging or re-flashing needed:
   current connection and recovers from a transient glitch. It re-enters pairing
   inquiry **only if no controller is paired**; with a controller already in memory
   it boots quietly and waits for that controller to reconnect on its own (no
-  inquiry, no LED blink). (Clicks register after a brief pause, to allow for a
-  second/third click.)
+  inquiry, no LED blink).
 - **Triple click:** **Reboot into BOOTSEL** — the dongle re-enumerates as a USB
   mass-storage drive so you can drag on a new `.uf2`, without holding BOOTSEL while
   plugging in.

--- a/README.md
+++ b/README.md
@@ -161,9 +161,7 @@ Or download precompiled firmware from GitHub Actions.
 
 Wake-on-PS is now built into the standard firmware — there is no separate `feat/usb-wake` branch or `ds5-bridge-wake.uf2`
 build. It is **disabled by default**; turn it on with the **Wake PC from sleep on PS button** toggle in the
-[web config](#configuration). When enabled, the dongle presents a HID keyboard interface and advertises USB remote
-wakeup so a controller button can wake the PC; when disabled, that interface is not enumerated. See
-[Wake-on-PS](#wake-on-ps-optional) for setup.
+[web config](#configuration). When enabled, the dongle advertises USB remote wakeup on the gamepad interface; when disabled, wake descriptors are not advertised. See [Wake-on-PS](#wake-on-ps-optional) for setup.
 
 It is recommended to read #60 and #61 before using this feature.
 
@@ -242,54 +240,28 @@ headers, the script asks to install the complete `gcc-arm-embedded` cask and poi
 ## Xbox Game Bar (optional)
 
 The **PS button = Xbox Game Bar** toggle in the [web config](#configuration) maps the controller's PS button to
-keyboard shortcuts, sent over the same HID keyboard interface used by [Wake-on-PS](#wake-on-ps-optional):
+keyboard shortcuts, sent over a separate HID keyboard interface (only when the shortcut toggle is enabled):
 
 - **Short press** (tap and release) → `Win`+`G`, which opens the **Xbox Game Bar** overlay.
 - **Long press** (hold ≥ 750 ms) → `Win`+`Tab`, which opens **Task View**.
 
-The toggle is off by default, and the keyboard interface is only enumerated while it (or wake) is enabled. Note this
+The toggle is off by default, and the keyboard interface is only enumerated while the Xbox Game Bar shortcut is enabled. Note this
 only *opens* the Game Bar: the DualSense is not an XInput gamepad, so Windows won't let the controller navigate the
 overlay — use a mouse or keyboard for that.
 
 ## Wake-on-PS (optional)
 
-Enabling the **Wake PC from sleep on PS button** toggle in the [web config](#configuration) makes the dongle present a
-second HID interface (a boot keyboard) and advertise USB remote wakeup. A controller button press while the host is
-suspended then injects an **F15** keypress, waking the PC from **S3 sleep**. F15 was chosen because it has no default
-Windows or app binding — a stray fire never inserts characters or triggers shortcuts. The toggle is off by default, and
-the keyboard interface is only enumerated while it (or the Xbox Game Bar shortcut) is enabled.
+Enabling the **Wake PC from sleep on PS button** toggle in the [web config](#configuration) advertises USB remote wakeup on the existing DualSense gamepad interface — no extra keyboard is added. A controller button press while the host is suspended sends a USB remote-wakeup signal, then forwards the real DS5 gamepad input report so Windows sees controller activity. The toggle is off by default.
 
-Scope: **S3 only.** Modern Standby (S0ix) is not supported. To check your machine, run `powercfg /a` — you need
-"Standby (S3)" listed under available sleep states.
+Scope: **S3 only.** Modern Standby (S0ix) is not supported. To check your machine, run `powercfg /a` — you need "Standby (S3)" listed under available sleep states.
 
-After enabling the toggle (then **Reconnect USB** so the interface re-enumerates):
+After enabling the toggle (then **Save** so USB re-enumerates with wake descriptors):
 
-1. Open Device Manager → the new **HID Keyboard Device** (and its parent **USB Composite Device**) → Properties → Power
-   Management → tick **"Allow this device to wake the computer."**
+1. Open Device Manager → **Wireless Controller** / **HID-compliant game controller** (and parent **USB Composite Device**) → Properties → Power Management → tick **"Allow this device to wake the computer."**
 2. Verify with `powercfg /devicequery wake_armed`.
 3. Sleep the PC; press any button on the controller; the PC should wake within ~1 s.
-4. After a wake, `powercfg /lastwake` should attribute the wake to the HID Keyboard Device.
 
-> Wake also needs `SelectiveSuspendEnabled = 1` (a `REG_DWORD`) on the controller's audio interface (`MI_00`). Windows
-> only writes it at first install, so a runtime toggle may need it set manually. It lives under each per-instance
-> `Device Parameters` key:
->
-> ```
-> HKLM\SYSTEM\CurrentControlSet\Enum\USB\VID_054C&PID_0CE6&MI_00\<instance>\Device Parameters
->     SelectiveSuspendEnabled    (REG_DWORD) = 1
-> ```
->
-> `PID_0CE6` is the DualSense (`PID_0DF2` for the Edge), and `<instance>` is device/port-specific (e.g.
-> `6&212078ea&1&0000`), so there can be more than one node — set it on every one. An elevated PowerShell one-liner that
-> covers all present instances:
->
-> ```powershell
-> Get-ChildItem 'HKLM:\SYSTEM\CurrentControlSet\Enum\USB\VID_054C&PID_0CE6&MI_00' | ForEach-Object {
->   New-ItemProperty "$($_.PSPath)\Device Parameters" SelectiveSuspendEnabled -Value 1 -PropertyType DWord -Force }
-> ```
->
-> Then Reconnect USB or reboot. (Re-installing the device — clearing its Windows device cache and replugging — also
-> makes Windows write the value itself.)
+> **Do not** set `SelectiveSuspendEnabled` on the audio (`MI_00`) or HID (`MI_03`) interfaces — older wake builds used MS OS 2.0 registry keys that break controller speaker audio. If present, remove them and re-enumerate USB.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ You have two options:
 
 ***You may need to replug the Pico when the controller is in pairing mode.***
 
+Once a controller has been paired, the dongle reconnects to it **silently**: it
+stays in Bluetooth page scan, and the controller links back on its own when you
+turn it on (press **PS**) — no inquiry, and the onboard LED stays dark. The dongle
+only runs a discovery scan (with the LED blinking) when **no controller is paired**,
+or when you explicitly start one with a BOOTSEL **single click**. A power-off, idle
+timeout, sleep, restart, or dongle reboot therefore no longer kicks off a
+30-second pairing scan the way it used to.
+
 ### BOOTSEL button: switch, reboot, or clear controllers
 
 While the firmware is running, the Pico's **BOOTSEL button** doubles as a
@@ -62,16 +70,20 @@ controller and reset control — no unplugging or re-flashing needed:
   - If nothing is connected, a 30-second scan starts to pair a new controller.
     Put the DualSense into pairing mode (hold **PS + Create/Share** until the
     light bar flashes) while the scan runs.
-- **Double click:** **Reboot the Pico** — a normal firmware restart: re-enters
-  pairing inquiry, drops the current connection, and recovers from a transient
-  glitch. (Clicks register after a brief pause, to allow for a second/third click.)
+- **Double click:** **Reboot the Pico** — a normal firmware restart that drops the
+  current connection and recovers from a transient glitch. It re-enters pairing
+  inquiry **only if no controller is paired**; with a controller already in memory
+  it boots quietly and waits for that controller to reconnect on its own (no
+  inquiry, no LED blink). (Clicks register after a brief pause, to allow for a
+  second/third click.)
 - **Triple click:** **Reboot into BOOTSEL** — the dongle re-enumerates as a USB
   mass-storage drive so you can drag on a new `.uf2`, without holding BOOTSEL while
   plugging in.
 - **Long press (~1.5 s):** Disconnect and **forget every paired controller** — all
   stored pairings are deleted and blacklisted so they won't silently auto-reconnect,
-  even across a power cycle. The onboard LED flashes six times to confirm. To use a
-  forgotten controller again, put it back into **PS + Create/Share** pairing mode.
+  even across a power cycle. The onboard LED flashes six times to confirm. To pair a
+  controller again, start a scan with a **single click** (or replug the dongle) and
+  put it into **PS + Create/Share** pairing mode.
 
 > Triple click is a software path into the bootloader; you can also still enter it
 > the hardware way by holding BOOTSEL **while plugging in** the Pico (see

--- a/README.md
+++ b/README.md
@@ -64,12 +64,11 @@ While the firmware is running, the Pico's **BOOTSEL button** also manages paired
 controllers and resets the dongle — no unplugging or re-flashing needed:
 
 - **Short press (click):**
-  - If a controller is connected, the current one is disconnected (its pairing is
-    kept, so it can reconnect later). Use this to free the dongle to pair a
-    previously unknown controller.
-  - If nothing is connected, a 30-second scan starts to pair a new controller.
-    Put the DualSense into pairing mode (hold **PS + Create/Share** until the
-    light bar flashes) while the scan runs.
+  - **While a controller is connected** — disconnects it (pairing kept). The
+    dongle goes quiet and stays connectable, so a different already-paired
+    controller can take over.
+  - **While nothing is connected** — starts a 30-second pairing scan (put the new
+    controller into **PS + Create/Share** mode while the LED blinks).
 - **Double click:** **Reboot the Pico** — a normal firmware restart that drops the
   current connection and recovers from a transient glitch. It re-enters pairing
   inquiry **only if no controller is paired**; with a controller already in memory

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ timeout, sleep, restart, or dongle reboot therefore no longer kicks off a
 
 ### BOOTSEL button: switch, reboot, or clear controllers
 
-While the firmware is running, the Pico's **BOOTSEL button** doubles as a
-controller and reset control — no unplugging or re-flashing needed:
+While the firmware is running, the Pico's **BOOTSEL button** also manages paired
+controllers and resets the dongle — no unplugging or re-flashing needed:
 
 - **Short press (click):**
   - If a controller is connected, the current one is disconnected (its pairing is
-    kept, so it can reconnect later). Use this to free the dongle for a different
-    already-paired controller.
+    kept, so it can reconnect later). Use this to free the dongle to pair a
+    previously unknown controller.
   - If nothing is connected, a 30-second scan starts to pair a new controller.
     Put the DualSense into pairing mode (hold **PS + Create/Share** until the
     light bar flashes) while the scan runs.

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "state_mgr.h"
 #include "usb.h"
+#include "bt.h"
 
 #define INPUT_CHANNELS    4
 #define OUTPUT_CHANNELS   2
@@ -95,6 +96,13 @@ void update_mic_status() {
     bt_write(pkt,sizeof(pkt));
 }
 
+void audio_resync_speaker_path(void) {
+    if (!bt_is_connected()) return;
+    set_volume(get_config().speaker_volume, get_config().headset_volume);
+    set_gain(get_config().speaker_gain);
+    update_mic_status();
+}
+
 void __not_in_flash_func(audio_loop)() {
     // Mic playback: drain decoded mic PCM into the USB IN endpoint
     static mic_decode_element mic_pb{};
@@ -130,6 +138,7 @@ void __not_in_flash_func(audio_loop)() {
     if (frames == 0) {
         return;
     }
+    state_note_game_audio();
 
     static float audio_buf[512 * 2];
     static uint audio_buf_pos = 0;

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -200,7 +200,7 @@ void __not_in_flash_func(audio_loop)() {
         // SetStateData
         pkt[11] = 0x10 | 0 << 6 | 1 << 7;
         pkt[12] = 63;
-        state_set(pkt + 13,63);
+        state_embed_for_audio(pkt + 13, 63);
         // Haptics Audio Data
         pkt[76] = 0x12 | 0 << 6 | 1 << 7;
         pkt[77] = SAMPLE_SIZE;

--- a/src/audio.h
+++ b/src/audio.h
@@ -16,4 +16,8 @@ bool audio_mic_active();
 void mic_add_queue(uint8_t *data, uint16_t len);
 void update_mic_status();
 
+// Re-push speaker/headset volume + controller audio subscription after BT or USB
+// resume (needed when wake suspend cycles power off the controller radio).
+void audio_resync_speaker_path(void);
+
 #endif //DS5_BRIDGE_AUDIO_H

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -109,6 +109,10 @@ bool bt_disconnect() {
     return true;
 }
 
+bool bt_is_connected(void) {
+    return hid_interrupt_cid != 0;
+}
+
 void bt_get_signal_strength(int8_t *rssi) {
     // gap_read_rssi() completes asynchronously, so this function can only
     // return the last cached RSSI value. Trigger a refresh afterwards so a
@@ -744,6 +748,12 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
                     report32[2] = 0x10 | 0 << 6 | 1 << 7;
                     report32[3] = 0x3f; // 63 bytes
                     state_set(report32 + 4,sizeof(SetStateData));
+                    // Connect-only: don't claim the light bar on the first report;
+                    // persistent state keeps Allow* flags so host/game lighting still works.
+                    auto *connect_state = reinterpret_cast<SetStateData *>(report32 + 4);
+                    connect_state->AllowLedColor = 0;
+                    connect_state->AllowColorLightFadeAnimation = 0;
+                    connect_state->AllowLightBrightnessChange = 0;
                     bt_write(report32, sizeof(report32));
 
                     const auto mtu = l2cap_get_remote_mtu_for_local_cid(hid_interrupt_cid);

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -741,19 +741,12 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
 
                     init_feature();
                     // 初始化手柄状态
-                    state_init();
                     uint8_t report32[142]{};
                     report32[0] = 0x32;
                     report32[1] = 0x10; // reportSeqCounter
                     report32[2] = 0x10 | 0 << 6 | 1 << 7;
                     report32[3] = 0x3f; // 63 bytes
-                    state_set(report32 + 4,sizeof(SetStateData));
-                    // Connect-only: don't claim the light bar on the first report;
-                    // persistent state keeps Allow* flags so host/game lighting still works.
-                    auto *connect_state = reinterpret_cast<SetStateData *>(report32 + 4);
-                    connect_state->AllowLedColor = 0;
-                    connect_state->AllowColorLightFadeAnimation = 0;
-                    connect_state->AllowLightBrightnessChange = 0;
+                    state_set(report32 + 4, sizeof(SetStateData));
                     bt_write(report32, sizeof(report32));
 
                     const auto mtu = l2cap_get_remote_mtu_for_local_cid(hid_interrupt_cid);

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -355,10 +355,7 @@ void bt_inquiring_led() {
     }
 }
 
-// True if BTstack already has a stored controller link key. When we know a
-// controller we skip the boot inquiry and just wait on page scan -- a paired
-// controller reconnects on its own (gap_connectable_control). No stored key
-// (fresh dongle, or after a BOOTSEL-hold clear-all) -> inquire to pair one.
+// True if BTstack has at least one stored controller link key.
 static bool bt_has_stored_link_key() {
     btstack_link_key_iterator_t it;
     if (!gap_link_key_iterator_init(&it)) return false;
@@ -381,11 +378,8 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             printf("[BT] State: %u\n", state);
             if (state == HCI_STATE_WORKING) {
                 bt_blacklist_load();
-                // Only inquire on boot when we don't already know a controller.
-                // With a stored link key, the paired controller reconnects on its
-                // own via page scan, so stay dark and skip the inquiry blink. Pair
-                // a different controller with the BOOTSEL single-click; a clear-all
-                // (BOOTSEL hold) wipes the keys so the next boot scans again.
+                // Only inquire on boot when no controller is paired; a stored
+                // controller reconnects on its own via page scan.
                 if (bt_has_stored_link_key()) {
                     printf("[BT] Stack ready, stored controller -> page scan, no inquiry\n");
                 } else {
@@ -629,12 +623,9 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             battery_led_on_disconnect();
 #endif
             printf("[HCI] Disconnected reason=0x%02X\n", reason);
-            // Reverts #150: do NOT auto-restart inquiry on disconnect. Page scan
-            // stays enabled (gap_connectable_control above), so a previously-paired
-            // controller reconnects on its own when powered back on. Discovering a
-            // *different* controller is an explicit action (BOOTSEL single-click).
-            // This keeps the LED dark after every power-off / sleep / timeout
-            // instead of blinking the 30 s inquiry.
+            // No inquiry on disconnect: page scan (above) handles reconnect of a
+            // paired controller; discovering a new one is the explicit BOOTSEL
+            // single-click.
             bt_inquiring = false;
             break;
         }

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -355,6 +355,21 @@ void bt_inquiring_led() {
     }
 }
 
+// True if BTstack already has a stored controller link key. When we know a
+// controller we skip the boot inquiry and just wait on page scan -- a paired
+// controller reconnects on its own (gap_connectable_control). No stored key
+// (fresh dongle, or after a BOOTSEL-hold clear-all) -> inquire to pair one.
+static bool bt_has_stored_link_key() {
+    btstack_link_key_iterator_t it;
+    if (!gap_link_key_iterator_init(&it)) return false;
+    bd_addr_t addr;
+    link_key_t key;
+    link_key_type_t type;
+    const bool has_key = gap_link_key_iterator_get_next(&it, addr, key, &type);
+    gap_link_key_iterator_done(&it);
+    return has_key;
+}
+
 static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size) {
     (void) channel;
 
@@ -365,10 +380,19 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             const uint8_t state = btstack_event_state_get_state(packet);
             printf("[BT] State: %u\n", state);
             if (state == HCI_STATE_WORKING) {
-                printf("[BT] Stack ready, start inquiry\n");
                 bt_blacklist_load();
-                gap_inquiry_start(30);
-                bt_inquiring = true;
+                // Only inquire on boot when we don't already know a controller.
+                // With a stored link key, the paired controller reconnects on its
+                // own via page scan, so stay dark and skip the inquiry blink. Pair
+                // a different controller with the BOOTSEL single-click; a clear-all
+                // (BOOTSEL hold) wipes the keys so the next boot scans again.
+                if (bt_has_stored_link_key()) {
+                    printf("[BT] Stack ready, stored controller -> page scan, no inquiry\n");
+                } else {
+                    printf("[BT] Stack ready, no stored controller -> start inquiry\n");
+                    gap_inquiry_start(30);
+                    bt_inquiring = true;
+                }
             }
             break;
         }

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -605,8 +605,13 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             battery_led_on_disconnect();
 #endif
             printf("[HCI] Disconnected reason=0x%02X\n", reason);
-            gap_inquiry_start(30);
-            bt_inquiring = true;
+            // Reverts #150: do NOT auto-restart inquiry on disconnect. Page scan
+            // stays enabled (gap_connectable_control above), so a previously-paired
+            // controller reconnects on its own when powered back on. Discovering a
+            // *different* controller is an explicit action (BOOTSEL single-click).
+            // This keeps the LED dark after every power-off / sleep / timeout
+            // instead of blinking the 30 s inquiry.
+            bt_inquiring = false;
             break;
         }
 

--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -17,10 +17,80 @@
 #include "audio.h"
 
 // spk_active (main.cpp) + audio_mic_active() (audio.cpp) are surfaced in the
-// 0xf9 command response so the config UI can display the real gated mic/speaker
+// 0xf9 feature report so the config UI can display the real gated mic/speaker
 // state, reflecting the disable_mic / disable_speaker settings.
 extern bool spk_active;
 extern std::unordered_map<uint8_t, std::vector<uint8_t> > feature_data;
+
+bool is_pico_cmd(uint8_t report_id) {
+    return report_id == 0xf6 ||
+           report_id == 0xf7 ||
+           report_id == 0xf8 ||
+           report_id == 0xf9;
+}
+
+uint16_t pico_cmd_get(uint8_t report_id, uint8_t *buffer, uint16_t reqlen) {
+    if (report_id == 0xf7) {
+        printf("[HID] Receive 0xf7 getting config\n");
+        if (sizeof(Config_body) > reqlen) {
+            printf("[Config] Warning: Config_body overflow\n");
+        }
+        const auto len = std::min(sizeof(Config_body), static_cast<size_t>(reqlen));
+        memcpy(buffer, &get_config(), len);
+        return len;
+    }
+    if (report_id == 0xf8) {
+        printf("[HID] Receive 0xf8 getting firmware version\n");
+        const auto len = std::min(strlen(PICO_PROGRAM_VERSION_STRING), static_cast<size_t>(reqlen));
+        memcpy(buffer, PICO_PROGRAM_VERSION_STRING, len);
+        return len;
+    }
+    if (report_id == 0xf9) {
+        int8_t rssi = 0;
+        bt_get_signal_strength(&rssi);
+        if (reqlen == 0) {
+            return 0;
+        }
+        buffer[0] = rssi;
+        if (reqlen >= 2) {
+            uint8_t flags = 0x80;
+            if (audio_mic_active() && !get_config().disable_mic) flags |= 0x01;
+            if (spk_active && !get_config().disable_speaker) flags |= 0x02;
+            buffer[1] = flags;
+            return 2;
+        }
+        return 1;
+    }
+    return 0;
+}
+
+void pico_cmd_set(uint8_t report_id, uint8_t const *buffer, uint16_t bufsize) {
+    (void) report_id;
+    if (bufsize == 0) {
+        return;
+    }
+
+    if (buffer[0] == 0x01) {
+#if ENABLE_VERBOSE
+        printf("[CMD] Enter config set func\n");
+#endif
+        set_config(buffer + 1, bufsize - 1);
+    }
+    if (buffer[0] == 0x02) {
+        printf("[CMD] Enter config save func\n");
+        config_save();
+    }
+    if (buffer[0] == 0x03) {
+        printf("[CMD] Enter tud reconnect func\n");
+        tud_disconnect();
+        sleep_ms(150);
+        tud_connect();
+    }
+    if (buffer[0] == 0x04) {
+        printf("[CMD] Reboot to BOOTSEL (USB bootloader)\n");
+        reset_usb_boot(0, 0);
+    }
+}
 
 template<typename T>
 static bool read_config_value(T &value, uint8_t const *buffer, uint16_t bufsize) {
@@ -201,16 +271,11 @@ static bool get_config_field(uint8_t field_id, uint8_t *buffer, uint16_t bufsize
     }
 }
 
-void pico_cmd_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize) {
-    // 0x01 update config field in variable: field_id + typed value
-    // 0x02 write config to flash
-    // 0x03 reconnect tinyusb device;
-    // 0x04 query config field: field_id (0x00 = config_version)
-
+void pico_cmd_legacy_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize) {
     switch (cmd_id) {
         case 0x01: {
 #if ENABLE_VERBOSE
-            printf("[CMD] Enter config set func\n");
+            printf("[CMD] Enter legacy config set func\n");
 #endif
             bool success = false;
             if (bufsize < 1) {
@@ -274,14 +339,9 @@ void pico_cmd_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize) {
             uint8_t buf[63]{};
             buf[0] = 0x66;
             buf[1] = 0x06;
-            // [-128,0]
             int8_t rssi = 0;
             bt_get_signal_strength(&rssi);
             buf[2] = rssi;
-            // byte 3: real audio gating state, for the config UI to display.
-            //   bit7 = valid marker
-            //   bit0 = controller mic actually streaming (host opened it AND !disable_mic)
-            //   bit1 = controller speaker actually driven (host opened it AND !disable_speaker)
             uint8_t flags = 0x80;
             if (audio_mic_active() && !get_config().disable_mic) flags |= 0x01;
             if (spk_active && !get_config().disable_speaker) flags |= 0x02;
@@ -289,13 +349,5 @@ void pico_cmd_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize) {
             feature_data[0x81].assign(buf, buf + sizeof(buf));
             break;
         }
-        /*case 0x07: {
-            // Reboot into BOOTSEL (USB mass-storage bootloader) so the dongle can be
-            // reflashed from the host without the physical BOOTSEL button. The
-            // controller's enumeration is unchanged -- this is just a host command.
-            printf("[CMD] Reboot to BOOTSEL (USB bootloader)\n");
-            reset_usb_boot(0, 0); // noreturn
-            break;
-        }*/
     }
 }

--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -78,7 +78,9 @@ void pico_cmd_set(uint8_t report_id, uint8_t const *buffer, uint16_t bufsize) {
     }
     if (buffer[0] == 0x02) {
         printf("[CMD] Enter config save func\n");
-        config_save();
+        if (config_save()) {
+            config_schedule_usb_reconnect_if_layout_changed();
+        }
     }
     if (buffer[0] == 0x03) {
         printf("[CMD] Enter tud reconnect func\n");

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -7,6 +7,9 @@
 
 #include <stdint.h>
 
-void pico_cmd_set(uint8_t report_id, uint8_t const *buffer,uint16_t bufsize);
+bool is_pico_cmd(uint8_t report_id);
+uint16_t pico_cmd_get(uint8_t report_id, uint8_t *buffer, uint16_t reqlen);
+void pico_cmd_set(uint8_t report_id, uint8_t const *buffer, uint16_t bufsize);
+void pico_cmd_legacy_set(uint8_t cmd_id, uint8_t const *buffer, uint16_t bufsize);
 
 #endif //DS5_BRIDGE_CMD_H

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -13,12 +13,24 @@
 #include "hardware/sync.h"
 #include "pico/cyw43_arch.h"
 #include "pico/flash.h"
+#include "pico/time.h"
+#include "device/usbd.h"
 
 constexpr uint32_t CONFIG_MAGIC = 0x66ccff00;
 constexpr uint16_t CONFIG_VERSION = 4;
 constexpr uint32_t CONFIG_FLASH_OFFSET = PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE;
 static Config config{};
 bool is_dse = false;
+
+#ifdef ENABLE_WAKE_HID
+static bool enum_kbd_layout = false;
+static bool enum_wake_layout = false;
+static bool pending_usb_reconnect = false;
+
+static bool config_kbd_layout(const Config_body &body) {
+    return body.enable_wake || body.ps_shortcut_enabled;
+}
+#endif
 
 // 编译期保护
 // 判断Config结构体是否能放进flash 256bytes
@@ -161,6 +173,34 @@ bool config_save() {
 
 Config_body& get_config() {
     return config.body;
+}
+
+void config_note_usb_enumerated_layout(void) {
+#ifdef ENABLE_WAKE_HID
+    enum_kbd_layout = config_kbd_layout(config.body);
+    enum_wake_layout = config.body.enable_wake;
+#endif
+}
+
+void config_schedule_usb_reconnect_if_layout_changed(void) {
+#ifdef ENABLE_WAKE_HID
+    if (config_kbd_layout(config.body) != enum_kbd_layout ||
+        config.body.enable_wake != enum_wake_layout) {
+        pending_usb_reconnect = true;
+    }
+#endif
+}
+
+void config_usb_reconnect_task(void) {
+#ifdef ENABLE_WAKE_HID
+    if (!pending_usb_reconnect) {
+        return;
+    }
+    pending_usb_reconnect = false;
+    tud_disconnect();
+    sleep_ms(150);
+    tud_connect();
+#endif
 }
 
 void set_config(const uint8_t *new_config, const uint16_t len) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -28,7 +28,8 @@ static bool enum_wake_layout = false;
 static bool pending_usb_reconnect = false;
 
 static bool config_kbd_layout(const Config_body &body) {
-    return body.enable_wake || body.ps_shortcut_enabled;
+    // Keyboard is only for the Xbox Game Bar shortcut; wake uses the gamepad HID path.
+    return body.ps_shortcut_enabled;
 }
 #endif
 

--- a/src/config.h
+++ b/src/config.h
@@ -25,7 +25,7 @@ struct __attribute__((packed)) Config_body {
     uint8_t ps_shortcut_enabled; // 0: disabled, 1: enabled (Xbox Game Bar via HID keyboard)
     uint8_t disable_mic; // bool: 0 enable (default), 1 disable controller mic
     uint8_t disable_speaker; // bool: 0 enable (default), 1 disable speaker/headset
-    uint8_t enable_wake; // bool: 0 disabled (default), 1 wake host on PS press (USB remote wakeup)
+    uint8_t enable_wake; // bool: 0 disabled (default), 1 wake host from DS5 input via USB remote wakeup
 };
 
 struct __attribute__((packed)) Config {
@@ -43,9 +43,9 @@ void set_config(const uint8_t *new_config, const uint16_t len);
 void config_valid();
 void set_config(const Config_body &new_config);
 void set_gain(uint8_t value);
-// Record the wake/keyboard USB layout the host enumerated (call from tud_mount_cb).
+// Record USB layout the host enumerated (call from tud_mount_cb).
 void config_note_usb_enumerated_layout(void);
-// After save, re-enumerate if wake/keyboard layout no longer matches the host.
+// After save, re-enumerate if keyboard shortcut or wake BOS layout changed.
 void config_schedule_usb_reconnect_if_layout_changed(void);
 void config_usb_reconnect_task(void);
 extern bool is_dse;

--- a/src/config.h
+++ b/src/config.h
@@ -43,6 +43,11 @@ void set_config(const uint8_t *new_config, const uint16_t len);
 void config_valid();
 void set_config(const Config_body &new_config);
 void set_gain(uint8_t value);
+// Record the wake/keyboard USB layout the host enumerated (call from tud_mount_cb).
+void config_note_usb_enumerated_layout(void);
+// After save, re-enumerate if wake/keyboard layout no longer matches the host.
+void config_schedule_usb_reconnect_if_layout_changed(void);
+void config_usb_reconnect_task(void);
 extern bool is_dse;
 
 #endif //DS5_BRIDGE_CONFIG_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,7 +140,15 @@ void __not_in_flash_func(on_bt_data)(CHANNEL_TYPE channel, uint8_t *data, uint16
 // Return zero will cause the stack to STALL request
 uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t *buffer,
                                uint16_t reqlen) {
+    (void) report_type;
+
+    if (is_pico_cmd(report_id)) {
+        return pico_cmd_get(report_id, buffer, reqlen);
+    }
+
 #ifdef ENABLE_WAKE_HID
+    // Wake keyboard is a second HID interface; WebHID may open it instead of
+    // the gamepad after enable_wake adds it to the composite descriptor.
     if (itf == 1) {
         if (reqlen >= 8) {
             memset(buffer, 0, 8);
@@ -150,11 +158,6 @@ uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t
     }
 #endif
     (void) itf;
-    (void) report_type;
-
-    if (is_pico_cmd(report_id)) {
-        return pico_cmd_get(report_id, buffer, reqlen);
-    }
 
     // DSE profiles: while the unlock + prefetch is still in progress, return 0
     // (NAK) for profile reads so the PS app retries rather than caching an
@@ -199,14 +202,6 @@ bool tud_audio_set_itf_cb(uint8_t rhport, tusb_control_request_t const *p_reques
 // received data on OUT endpoint ( Report ID = 0, Type = 0 )
 void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer,
                            uint16_t bufsize) {
-#ifdef ENABLE_WAKE_HID
-    if (itf == 1) {
-        // Drop keyboard SET_REPORT (host LED state).
-        return;
-    }
-#endif
-
-    (void) itf;
     (void) report_type;
 
     if (is_pico_cmd(report_id)) {
@@ -216,6 +211,15 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
         pico_cmd_set(report_id, buffer, bufsize);
         return;
     }
+
+#ifdef ENABLE_WAKE_HID
+    if (itf == 1) {
+        // Drop keyboard SET_REPORT (host LED state).
+        return;
+    }
+#endif
+
+    (void) itf;
 
     // INTERRUPT OUT
     if (report_id == 0) {
@@ -332,6 +336,7 @@ int main() {
         audio_loop();
         interrupt_loop();
         state_post_game_task();
+        config_usb_reconnect_task();
 #if ENABLE_BATT_LED
         battery_led_tick();
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,8 +147,8 @@ uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t
     }
 
 #ifdef ENABLE_WAKE_HID
-    // Wake keyboard is a second HID interface; WebHID may open it instead of
-    // the gamepad after enable_wake adds it to the composite descriptor.
+    // Game Bar shortcut keyboard (HID instance 1); WebHID may open it instead of
+    // the gamepad when ps_shortcut_enabled adds the second HID interface.
     if (itf == 1) {
         if (reqlen >= 8) {
             memset(buffer, 0, 8);
@@ -189,6 +189,9 @@ bool tud_audio_set_itf_cb(uint8_t rhport, tusb_control_request_t const *p_reques
         printf("[AUDIO] Set interface Speaker to alternate setting %d\n", alt);
         spk_active = alt;
         state_note_speaker_alt(was_active, alt);
+        if (alt && !was_active) {
+            audio_resync_speaker_path();
+        }
     }
     if (itf == 2) { // ITF_NUM_AUDIO_STREAMING_IN (microphone)
         printf("[AUDIO] Set interface Microphone to alternate setting %d\n", alt);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,8 +181,12 @@ bool tud_audio_set_itf_cb(uint8_t rhport, tusb_control_request_t const *p_reques
     uint8_t const alt = tu_u16_low(p_request->wValue); // bAlternateSetting
 
     if (itf == 1) {
+        const bool was_active = spk_active;
         printf("[AUDIO] Set interface Speaker to alternate setting %d\n", alt);
         spk_active = alt;
+        if (was_active && !alt) {
+            state_restore_idle_lights();
+        }
     }
     if (itf == 2) { // ITF_NUM_AUDIO_STREAMING_IN (microphone)
         printf("[AUDIO] Set interface Microphone to alternate setting %d\n", alt);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,10 +150,11 @@ uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t
     }
 #endif
     (void) itf;
-    (void) report_id;
     (void) report_type;
-    (void) buffer;
-    (void) reqlen;
+
+    if (is_pico_cmd(report_id)) {
+        return pico_cmd_get(report_id, buffer, reqlen);
+    }
 
     // DSE profiles: while the unlock + prefetch is still in progress, return 0
     // (NAK) for profile reads so the PS app retries rather than caching an
@@ -206,10 +207,15 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
 #endif
 
     (void) itf;
-    (void) report_id;
     (void) report_type;
-    (void) buffer;
-    (void) bufsize;
+
+    if (is_pico_cmd(report_id)) {
+#if ENABLE_VERBOSE
+        printf("[HID] Receive 0x%02X config command funcid:0x%02X\n", report_id, buffer[0]);
+#endif
+        pico_cmd_set(report_id, buffer, bufsize);
+        return;
+    }
 
     // INTERRUPT OUT
     if (report_id == 0) {
@@ -239,7 +245,7 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
 #endif
 
         // 0x80 0x66 cmd_id payload...
-        pico_cmd_set(buffer[1], buffer + 2, bufsize - 2);
+        pico_cmd_legacy_set(buffer[1], buffer + 2, bufsize - 2);
         return;
     }
     if (report_id == 0x80 ||

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,9 +184,7 @@ bool tud_audio_set_itf_cb(uint8_t rhport, tusb_control_request_t const *p_reques
         const bool was_active = spk_active;
         printf("[AUDIO] Set interface Speaker to alternate setting %d\n", alt);
         spk_active = alt;
-        if (was_active && !alt) {
-            state_restore_idle_lights();
-        }
+        state_note_speaker_alt(was_active, alt);
     }
     if (itf == 2) { // ITF_NUM_AUDIO_STREAMING_IN (microphone)
         printf("[AUDIO] Set interface Microphone to alternate setting %d\n", alt);
@@ -206,6 +204,7 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
         return;
     }
 #endif
+
     (void) itf;
     (void) report_id;
     (void) report_type;
@@ -326,6 +325,7 @@ int main() {
         wake_task();
         audio_loop();
         interrupt_loop();
+        state_post_game_task();
 #if ENABLE_BATT_LED
         battery_led_tick();
 #endif

--- a/src/state_mgr.cpp
+++ b/src/state_mgr.cpp
@@ -9,6 +9,9 @@
 
 #include "config.h"
 #include "utils.h"
+#include "bt.h"
+
+extern int reportSeqCounter;
 
 namespace {
     constexpr size_t kAudioControlOffset = offsetof(SetStateData, MuteLightMode) - sizeof(uint8_t);
@@ -39,13 +42,6 @@ void state_init() {
     state.VolumeHeadphones = get_config().headset_volume;
     set_volume(get_config().speaker_volume,get_config().headset_volume);
     set_gain(get_config().speaker_gain);
-
-    // Deliberately leave the light bar to the controller's own default: clear
-    // the colour/fade/brightness flags so the connect report doesn't claim the
-    // RGB strip.
-    state.AllowLedColor = 0;
-    state.AllowColorLightFadeAnimation = 0;
-    state.AllowLightBrightnessChange = 0;
 }
 
 void state_set(uint8_t *data, const uint8_t size) {
@@ -193,4 +189,41 @@ void set_volume(const uint8_t speaker,const uint8_t headset) {
 void set_gain(const uint8_t value) {
     state.SpeakerCompPreGain = value;
     state.BeamformingEnable = true;
+}
+
+static void push_setstate_report(const SetStateData *payload, const bool pulse_reset_lights)
+{
+    if (!bt_is_connected()) {
+        return;
+    }
+    uint8_t outputData[78]{};
+    outputData[0] = 0x31;
+    outputData[1] = static_cast<uint8_t>(reportSeqCounter << 4);
+    if (++reportSeqCounter == 256) {
+        reportSeqCounter = 0;
+    }
+    outputData[2] = 0x10;
+    memcpy(outputData + 3, payload, sizeof(SetStateData));
+    if (pulse_reset_lights) {
+        outputData[4] |= static_cast<uint8_t>(1u << 3);
+    }
+    bt_write(outputData, sizeof(outputData));
+}
+
+void state_restore_idle_lights(void)
+{
+    if (!bt_is_connected()) {
+        return;
+    }
+    state_init();
+    SetStateData idle{};
+    memcpy(&idle, &state, sizeof(SetStateData));
+    idle.AllowLedColor = 1;
+    idle.AllowColorLightFadeAnimation = 1;
+    idle.AllowLightBrightnessChange = 1;
+
+    push_setstate_report(&idle, true);
+    idle.ResetLights = 0;
+    push_setstate_report(&idle, false);
+    memcpy(&state, &idle, sizeof(SetStateData));
 }

--- a/src/state_mgr.cpp
+++ b/src/state_mgr.cpp
@@ -39,6 +39,13 @@ void state_init() {
     state.VolumeHeadphones = get_config().headset_volume;
     set_volume(get_config().speaker_volume,get_config().headset_volume);
     set_gain(get_config().speaker_gain);
+
+    // Deliberately leave the light bar to the controller's own default: clear
+    // the colour/fade/brightness flags so the connect report doesn't claim the
+    // RGB strip.
+    state.AllowLedColor = 0;
+    state.AllowColorLightFadeAnimation = 0;
+    state.AllowLightBrightnessChange = 0;
 }
 
 void state_set(uint8_t *data, const uint8_t size) {

--- a/src/state_mgr.cpp
+++ b/src/state_mgr.cpp
@@ -44,6 +44,21 @@ namespace {
     constexpr size_t kPlayerIndicatorsOffset = offsetof(SetStateData, LedRed) - sizeof(uint8_t);
 
     absolute_time_t post_game_lights_at = nil_time;
+    absolute_time_t wake_lights_grace_until = nil_time;
+    bool game_audio_active = false;
+    bool host_usb_suspended = false;
+
+    constexpr uint32_t kWakeLightsGraceMs = 15000;
+
+    bool wake_lights_grace_active(void)
+    {
+        return !is_nil_time(wake_lights_grace_until) && !time_reached(wake_lights_grace_until);
+    }
+
+    bool in_game_light_mode(void)
+    {
+        return spk_active || game_audio_active || wake_lights_grace_active();
+    }
 
     void clear_light_allows(SetStateData *payload)
     {
@@ -146,7 +161,7 @@ void state_embed_for_audio(uint8_t *data, const uint8_t size)
         printf("[StateMgr] Warning: State embed over %u bytes\n", kSetStateSize);
     }
     memcpy(data, &state, size);
-    if (!spk_active) {
+    if (!in_game_light_mode()) {
         clear_light_allows(reinterpret_cast<SetStateData *>(data));
     }
 }
@@ -293,16 +308,43 @@ void state_note_speaker_alt(const bool was_active, const bool now_active)
 {
     if (now_active) {
         post_game_lights_at = nil_time;
+        wake_lights_grace_until = nil_time;
         return;
     }
     if (was_active) {
-        post_game_lights_at = make_timeout_time_ms(kPostGameLightDelayMs);
+        game_audio_active = false;
+        // S3/selective suspend closes the speaker alt — not a game exit.
+        if (!host_usb_suspended) {
+            post_game_lights_at = make_timeout_time_ms(kPostGameLightDelayMs);
+        }
     }
+}
+
+void state_note_game_audio(void)
+{
+    game_audio_active = true;
+    wake_lights_grace_until = nil_time;
+}
+
+void state_note_usb_suspend(void)
+{
+    host_usb_suspended = true;
+    post_game_lights_at = nil_time;
+}
+
+void state_on_host_usb_resume(void)
+{
+    host_usb_suspended = false;
+    post_game_lights_at = nil_time;
+    spk_active = false;
+    game_audio_active = false;
+    wake_lights_grace_until = make_timeout_time_ms(kWakeLightsGraceMs);
 }
 
 void state_post_game_task(void)
 {
-    if (spk_active || is_nil_time(post_game_lights_at) || !time_reached(post_game_lights_at)) {
+    if (in_game_light_mode() || is_nil_time(post_game_lights_at) ||
+        !time_reached(post_game_lights_at)) {
         return;
     }
     post_game_lights_at = nil_time;

--- a/src/state_mgr.cpp
+++ b/src/state_mgr.cpp
@@ -5,22 +5,17 @@
 #include "state_mgr.h"
 
 #include <cstddef>
+#include <cstdio>
 #include <cstring>
 
 #include "config.h"
 #include "utils.h"
 #include "bt.h"
+#include "pico/time.h"
 
 extern int reportSeqCounter;
-
-namespace {
-    constexpr size_t kAudioControlOffset = offsetof(SetStateData, MuteLightMode) - sizeof(uint8_t);
-    constexpr size_t kMuteControlOffset = offsetof(SetStateData, RightTriggerFFB) - sizeof(uint8_t);
-    constexpr size_t kMotorPowerLevelOffset = offsetof(SetStateData, HostTimestamp) + sizeof(uint32_t);
-    constexpr size_t kAudioControl2Offset = kMotorPowerLevelOffset + sizeof(uint8_t);
-    constexpr size_t kHapticLowPassFilterOffset = offsetof(SetStateData, LightFadeAnimation) - 2 * sizeof(uint8_t);
-    constexpr size_t kPlayerIndicatorsOffset = offsetof(SetStateData, LedRed) - sizeof(uint8_t);
-}
+extern uint8_t interrupt_in_data[63];
+extern bool spk_active;
 
 static constexpr uint8_t state_init_data[63] = {
     0xfd, 0xf7, 0x0, 0x0,
@@ -36,6 +31,100 @@ static constexpr uint8_t state_init_data[63] = {
 
 SetStateData state{};
 
+namespace {
+    constexpr size_t kSetStateSize = 63;
+    constexpr uint32_t kMinSensorTimestamp = 10200000u;
+    constexpr uint32_t kPostGameLightDelayMs = 2000;
+
+    constexpr size_t kAudioControlOffset = offsetof(SetStateData, MuteLightMode) - sizeof(uint8_t);
+    constexpr size_t kMuteControlOffset = offsetof(SetStateData, RightTriggerFFB) - sizeof(uint8_t);
+    constexpr size_t kMotorPowerLevelOffset = offsetof(SetStateData, HostTimestamp) + sizeof(uint32_t);
+    constexpr size_t kAudioControl2Offset = kMotorPowerLevelOffset + sizeof(uint8_t);
+    constexpr size_t kHapticLowPassFilterOffset = offsetof(SetStateData, LightFadeAnimation) - 2 * sizeof(uint8_t);
+    constexpr size_t kPlayerIndicatorsOffset = offsetof(SetStateData, LedRed) - sizeof(uint8_t);
+
+    absolute_time_t post_game_lights_at = nil_time;
+
+    void clear_light_allows(SetStateData *payload)
+    {
+        payload->AllowLedColor = 0;
+        payload->AllowColorLightFadeAnimation = 0;
+        payload->AllowLightBrightnessChange = 0;
+        payload->AllowPlayerIndicators = 0;
+        payload->AllowMuteLight = 0;
+        payload->ResetLights = 0;
+    }
+
+    uint32_t controller_sensor_timestamp(void)
+    {
+        uint32_t ts = 0;
+        memcpy(&ts, interrupt_in_data + 27, sizeof(ts));
+        if (ts < kMinSensorTimestamp) {
+            ts = kMinSensorTimestamp;
+        }
+        return ts;
+    }
+
+    void push_setstate_report(const SetStateData *payload, const bool pulse_reset_lights)
+    {
+        if (!bt_is_connected()) {
+            return;
+        }
+        uint8_t outputData[78]{};
+        outputData[0] = 0x31;
+        outputData[1] = static_cast<uint8_t>(reportSeqCounter << 4);
+        if (++reportSeqCounter == 256) {
+            reportSeqCounter = 0;
+        }
+        outputData[2] = 0x10;
+        memcpy(outputData + 3, payload, sizeof(SetStateData));
+        if (pulse_reset_lights) {
+            outputData[4] |= static_cast<uint8_t>(1u << 3);
+        }
+        bt_write(outputData, sizeof(outputData));
+    }
+
+    void apply_idle_light_profile(SetStateData *payload)
+    {
+        // Gold bar bytes live at indices 52-54 in state_init_data, not at LedRed
+        // (offset 44). Assign explicitly — same as the pre-refactor restore path.
+        payload->LedRed = 0xff;
+        payload->LedGreen = 0xd7;
+        payload->LedBlue = 0x00;
+        payload->LightFadeAnimation = LightFadeAnimation::Nothing;
+        payload->LightBrightness = LightBrightness::Mid;
+        payload->PlayerLight1 = 0;
+        payload->PlayerLight2 = 0;
+        payload->PlayerLight3 = 0;
+        payload->PlayerLight4 = 0;
+        payload->PlayerLight5 = 0;
+        payload->PlayerLightFade = 0;
+    }
+
+    void apply_post_game_lights(void)
+    {
+        if (!bt_is_connected()) {
+            return;
+        }
+
+        apply_idle_light_profile(&state);
+
+        SetStateData out{};
+        memcpy(&out, &state, sizeof(SetStateData));
+        out.AllowLedColor = 1;
+        out.AllowColorLightFadeAnimation = 1;
+        out.AllowLightBrightnessChange = 1;
+        out.AllowMuteLight = 0;
+        out.ResetLights = 0;
+        out.HostTimestamp = controller_sensor_timestamp();
+
+        push_setstate_report(&out, true);
+        out.ResetLights = 0;
+        out.HostTimestamp = controller_sensor_timestamp();
+        push_setstate_report(&out, false);
+    }
+}
+
 void state_init() {
     memcpy(&state, state_init_data, sizeof(state));
     state.VolumeSpeaker = get_config().speaker_volume;
@@ -45,10 +134,21 @@ void state_init() {
 }
 
 void state_set(uint8_t *data, const uint8_t size) {
-    if (size > 63) {
-        printf("[StateMgr] Warning: State Set over 63 bytes\n");
+    if (size > kSetStateSize) {
+        printf("[StateMgr] Warning: State Set over %u bytes\n", kSetStateSize);
     }
     memcpy(data, &state, size);
+}
+
+void state_embed_for_audio(uint8_t *data, const uint8_t size)
+{
+    if (size > kSetStateSize) {
+        printf("[StateMgr] Warning: State embed over %u bytes\n", kSetStateSize);
+    }
+    memcpy(data, &state, size);
+    if (!spk_active) {
+        clear_light_allows(reinterpret_cast<SetStateData *>(data));
+    }
 }
 
 void state_update(const uint8_t *data, const uint8_t size) {
@@ -67,23 +167,17 @@ void state_update(const uint8_t *data, const uint8_t size) {
     auto *state_bytes = reinterpret_cast<uint8_t *>(&state);
     const auto copy_if_allowed = [&](const bool allowed, const size_t offset, const size_t length) {
         const size_t end = offset + length;
-        // offset/length are byte ranges in SetStateData. Skip the copy if the
-        // sender did not allow this field, or if a short report does not contain it.
         if (!allowed || end < offset || end > sizeof(state) || end > size) {
             return;
         }
 
         memcpy(state_bytes + offset, data + offset, length);
     };
-    /*auto set_bit = [](uint8_t &byte, const int bit, const bool value) {
-        byte = (byte & ~(1 << bit)) | (value << bit);
-    };*/
 
     state.EnableRumbleEmulation = update.EnableRumbleEmulation;
     state.UseRumbleNotHaptics = update.UseRumbleNotHaptics;
     state.EnableImprovedRumbleEmulation = update.EnableImprovedRumbleEmulation;
     if (update.RumbleEmulationLeft > 0 || update.RumbleEmulationRight > 0) {
-        // why doesn't ninja gaiden 4 enable UseRumbleNotHaptics
         state.UseRumbleNotHaptics = true;
     }
     if (state.EnableRumbleEmulation ||
@@ -177,7 +271,6 @@ void state_update(const uint8_t *data, const uint8_t size) {
 }
 
 void set_volume(const uint8_t value) {
-    // printf("[StateMgr] SetVolume: %u\n",value);
     if (get_config().sync_spk_headset_volume) {
         state.VolumeSpeaker = value;
         get_config().speaker_volume = value;
@@ -196,39 +289,22 @@ void set_gain(const uint8_t value) {
     state.BeamformingEnable = true;
 }
 
-static void push_setstate_report(const SetStateData *payload, const bool pulse_reset_lights)
+void state_note_speaker_alt(const bool was_active, const bool now_active)
 {
-    if (!bt_is_connected()) {
+    if (now_active) {
+        post_game_lights_at = nil_time;
         return;
     }
-    uint8_t outputData[78]{};
-    outputData[0] = 0x31;
-    outputData[1] = static_cast<uint8_t>(reportSeqCounter << 4);
-    if (++reportSeqCounter == 256) {
-        reportSeqCounter = 0;
+    if (was_active) {
+        post_game_lights_at = make_timeout_time_ms(kPostGameLightDelayMs);
     }
-    outputData[2] = 0x10;
-    memcpy(outputData + 3, payload, sizeof(SetStateData));
-    if (pulse_reset_lights) {
-        outputData[4] |= static_cast<uint8_t>(1u << 3);
-    }
-    bt_write(outputData, sizeof(outputData));
 }
 
-void state_restore_idle_lights(void)
+void state_post_game_task(void)
 {
-    if (!bt_is_connected()) {
+    if (spk_active || is_nil_time(post_game_lights_at) || !time_reached(post_game_lights_at)) {
         return;
     }
-    state_init();
-    SetStateData idle{};
-    memcpy(&idle, &state, sizeof(SetStateData));
-    idle.AllowLedColor = 1;
-    idle.AllowColorLightFadeAnimation = 1;
-    idle.AllowLightBrightnessChange = 1;
-
-    push_setstate_report(&idle, true);
-    idle.ResetLights = 0;
-    push_setstate_report(&idle, false);
-    memcpy(&state, &idle, sizeof(SetStateData));
+    post_game_lights_at = nil_time;
+    apply_post_game_lights();
 }

--- a/src/state_mgr.h
+++ b/src/state_mgr.h
@@ -15,6 +15,9 @@ void set_volume(uint8_t speaker, uint8_t headset);
 
 // Speaker USB alt changed: schedule post-game light restore when stream closes.
 void state_note_speaker_alt(bool was_active, bool now_active);
+void state_note_game_audio(void);
+void state_note_usb_suspend(void);
+void state_on_host_usb_resume(void);
 void state_post_game_task(void);
 
 #endif //DS5_BRIDGE_STATE_MGR_H

--- a/src/state_mgr.h
+++ b/src/state_mgr.h
@@ -11,5 +11,6 @@ void state_set(uint8_t *data, uint8_t size);
 void state_update(const uint8_t *data, uint8_t size);
 void set_volume(uint8_t value);
 void set_volume(uint8_t speaker, uint8_t headset);
+void state_restore_idle_lights(void);
 
 #endif //DS5_BRIDGE_STATE_MGR_H

--- a/src/state_mgr.h
+++ b/src/state_mgr.h
@@ -8,9 +8,13 @@
 
 void state_init();
 void state_set(uint8_t *data, uint8_t size);
+void state_embed_for_audio(uint8_t *data, uint8_t size);
 void state_update(const uint8_t *data, uint8_t size);
 void set_volume(uint8_t value);
 void set_volume(uint8_t speaker, uint8_t headset);
-void state_restore_idle_lights(void);
+
+// Speaker USB alt changed: schedule post-game light restore when stream closes.
+void state_note_speaker_alt(bool was_active, bool now_active);
+void state_post_game_task(void);
 
 #endif //DS5_BRIDGE_STATE_MGR_H

--- a/src/usb_descriptors.cpp
+++ b/src/usb_descriptors.cpp
@@ -127,9 +127,9 @@ tusb_desc_device_t desc_device =
 uint8_t const *tud_descriptor_device_cb(void) {
     desc_device.idProduct = ds_mode() ? 0x0CE6 : 0x0DF2;
     desc_device.iSerialNumber = get_config().disable_usb_sn ? 0x00 : 0x03;
-    // USB 2.1 (so the host requests the BOS / MS OS 2.0 selective-suspend opt-in)
-    // only when wake is enabled; plain USB 2.0 otherwise.
-    desc_device.bcdUSB = get_config().enable_wake ? 0x0210 : 0x0200;
+    // Stay on USB 2.0. USB 2.1 + BOS/MS OS selective-suspend breaks Windows speaker
+    // routing on this composite; wake only needs REMOTE_WAKEUP in the config descriptor.
+    desc_device.bcdUSB = 0x0200;
     return reinterpret_cast<uint8_t const *>(&desc_device);
 }
 
@@ -467,11 +467,10 @@ uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
         descriptor_configuration[offset - 16] = 0xB5;
     }
 
-    // Wake / Game Bar are runtime features. Advertise REMOTE_WAKEUP only when wake is
-    // on, and include the keyboard interface (the LAST descriptor block) only when wake
-    // OR the Game Bar shortcut is on. With both off this is byte-identical to the base.
+    // Wake uses the existing gamepad HID + USB remote wakeup (no extra interface).
+    // The keyboard block is only for the Xbox Game Bar shortcut.
     const bool wake = get_config().enable_wake;
-    const bool kbd = wake || get_config().ps_shortcut_enabled;
+    const bool kbd = get_config().ps_shortcut_enabled;
     descriptor_configuration[7] = wake ? 0xE0 : 0xC0; // bmAttributes (REMOTE_WAKEUP bit)
     const uint16_t total = kbd ? CONFIG_DESC_LEN_TOTAL
                                : (uint16_t) (CONFIG_DESC_LEN_TOTAL - CONFIG_DESC_LEN_WAKE_KBD);
@@ -906,7 +905,7 @@ _Static_assert(sizeof(desc_hid_report_kbd) == 45, "keyboard report descriptor le
 // Descriptor contents must exist long enough for transfer to complete
 uint8_t const *tud_hid_descriptor_report_cb(uint8_t itf) {
 #ifdef ENABLE_WAKE_HID
-    // HID instance 1 is the wake-only boot keyboard added by ENABLE_WAKE_HID.
+    // HID instance 1 is the boot keyboard for the Xbox Game Bar shortcut.
     if (itf == 1) return desc_hid_report_kbd;
 #endif
     (void) itf;
@@ -987,21 +986,10 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
 //--------------------------------------------------------------------+
 // Microsoft OS 2.0 descriptors (carried via BOS).
 //
-// Why this is here: the dongle is a composite device with USB Audio Class
-// interfaces. By default Windows audio engine policy keeps USB audio devices
-// at D0 even during system S3, blocking selective-suspend for the whole
-// composite. Without selective-suspend the device never enters USB suspend,
-// so tud_remote_wakeup() never works -- breaking wake-on-PS.
-//
-// MS OS 2.0 lets us tell Windows "yes, please selective-suspend this audio
-// function": we set the registry property "SelectiveSuspendEnabled" = 1 on
-// the audio function (interface 0). This causes Windows to write
-//   HKLM\SYSTEM\CurrentControlSet\Enum\USB\<VID&PID>\<instance>
-//        \Device Parameters\SelectiveSuspendEnabled = 1
-// at enumeration time, opting our audio function in to selective suspend
-// without breaking haptics.
-//
-// Reference: "Microsoft OS 2.0 Descriptors Specification".
+// MS OS 2.0 / BOS (DISABLED): selective-suspend registry on any composite function
+// breaks controller speaker audio while haptics still work. Wake uses only the
+// REMOTE_WAKEUP bit (bmAttributes 0xE0) -- no BOS, no USB 2.1, no registry keys.
+// The descriptor tables below are kept for reference but are not served at runtime.
 //--------------------------------------------------------------------+
 
 #define MS_OS_20_VENDOR_CODE 0x01
@@ -1022,10 +1010,8 @@ uint8_t const desc_bos[] = {
 };
 
 uint8_t const *tud_descriptor_bos_cb(void) {
-    // BOS carries the MS OS 2.0 selective-suspend opt-in, only meaningful for wake.
-    // When wake is off the device is USB 2.0 and the host won't ask -- guard anyway.
-    if (!get_config().enable_wake) return nullptr;
-    return desc_bos;
+    (void) get_config().enable_wake;
+    return nullptr;
 }
 
 uint8_t const desc_ms_os_20[] = {
@@ -1042,12 +1028,12 @@ uint8_t const desc_ms_os_20[] = {
     0x00,                                                     // bReserved
     U16_TO_U8S_LE(MS_OS_20_DESC_LEN - 0x0A),                  // wTotalLength of this subset
 
-    // --- Function Subset for the Audio function (8 bytes) ---
-    // Audio Control is interface 0; AudioStreaming OUT/IN are 1/2 -- this
-    // subset covers all three because they belong to the same function.
+    // --- Function Subset for the gamepad HID function (8 bytes) ---
+    // ITF_NUM_HID (interface 3): do NOT target audio (interface 0) -- that
+    // breaks speaker playback while leaving haptics channels alive.
     U16_TO_U8S_LE(0x0008),                                    // wLength
     U16_TO_U8S_LE(MS_OS_20_SUBSET_HEADER_FUNCTION),           // wDescriptorType
-    0x00,                                                     // bFirstInterface (audio control)
+    ITF_NUM_HID,                                              // bFirstInterface (gamepad HID)
     0x00,                                                     // bReserved
     U16_TO_U8S_LE(MS_OS_20_DESC_LEN - 0x0A - 0x08),           // wSubsetLength
 
@@ -1069,13 +1055,9 @@ TU_VERIFY_STATIC(sizeof(desc_ms_os_20) == MS_OS_20_DESC_LEN, "MS OS 2.0 descript
 // platform capability, then issues this vendor request to fetch the
 // descriptor set itself.
 bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const *request) {
-    if (!get_config().enable_wake) return false;
-    if (stage != CONTROL_STAGE_SETUP) return true;
-    if (request->bmRequestType_bit.type != TUSB_REQ_TYPE_VENDOR) return false;
-    if (request->bRequest == MS_OS_20_VENDOR_CODE && request->wIndex == 7) {
-        // wIndex == 7 -> MS_OS_20_DESCRIPTOR_INDEX
-        return tud_control_xfer(rhport, request, (void *)(uintptr_t)desc_ms_os_20, sizeof(desc_ms_os_20));
-    }
+    (void) rhport;
+    (void) stage;
+    (void) request;
     return false;
 }
 #endif // ENABLE_WAKE_HID

--- a/src/usb_descriptors.cpp
+++ b/src/usb_descriptors.cpp
@@ -385,8 +385,8 @@ uint8_t descriptor_configuration[] = {
     0x00, // bCountryCode: Not localized
     0x01, // bNumDescriptors: 1 report descriptor
     0x22, // bDescriptorType: Report
-    0x21, 0x01, // wDescriptorLength: 289 (0x0121) DS
-    // 0x95, 0x01, // wDescriptorLength: 405 (0x0195) DSE
+    0x41, 0x01, // wDescriptorLength: 321 (0x0141) DS
+    // 0xB5, 0x01, // wDescriptorLength: 437 (0x01B5) DSE
 
     // Endpoint Descriptor (HID IN: EP4)
     0x07, // bLength
@@ -462,9 +462,9 @@ uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
     descriptor_configuration[offset - 1] = bInterval;
     descriptor_configuration[offset - 8] = bInterval;
     if (ds_mode()) {
-        descriptor_configuration[offset - 16] = 0x21;
+        descriptor_configuration[offset - 16] = 0x41;
     }else {
-        descriptor_configuration[offset - 16] = 0x95;
+        descriptor_configuration[offset - 16] = 0xB5;
     }
 
     // Wake / Game Bar are runtime features. Advertise REMOTE_WAKEUP only when wake is
@@ -627,11 +627,27 @@ uint8_t const desc_hid_report_ds[] = {
     0x09, 0x36, //   Usage (0x36)
     0x95, 0x03, //   Report Count (3)
     0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF6, //   Report ID (-10)
+    0x09, 0x37, //   Usage (0x37)
+    0x95, 0x3F, //   Report Count (63)
+    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF7, //   Report ID (-9)
+    0x09, 0x38, //   Usage (0x38)
+    0x95, 0x3F, //   Report Count (63)
+    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF8, //   Report ID (-8)
+    0x09, 0x39, //   Usage (0x39)
+    0x95, 0x3F, //   Report Count (63)
+    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF9, //   Report ID (-7)
+    0x09, 0x3A, //   Usage (0x3A)
+    0x95, 0x3F, //   Report Count (63)
+    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
     0xC0, // End Collection
 
-    // 289 bytes
+    // 321 bytes
 };
-static_assert(sizeof(desc_hid_report_ds) == 289);
+static_assert(sizeof(desc_hid_report_ds) == 321);
 
 uint8_t const desc_hid_report_dse[] = {
     0x05, 0x01, // Usage Page (Generic Desktop Ctrls)
@@ -833,10 +849,26 @@ uint8_t const desc_hid_report_dse[] = {
     0x85, 0x7B, //   Report ID (123)
     0x09, 0x53, //   Usage (0x53)
     0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF6, //   Report ID (-10)
+    0x09, 0x37, //   Usage (0x37)
+    0x95, 0x3F, //   Report Count (63)
+    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF7, //   Report ID (-9)
+    0x09, 0x38, //   Usage (0x38)
+    0x95, 0x3F, //   Report Count (63)
+    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF8, //   Report ID (-8)
+    0x09, 0x39, //   Usage (0x39)
+    0x95, 0x3F, //   Report Count (63)
+    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF9, //   Report ID (-7)
+    0x09, 0x3A, //   Usage (0x3A)
+    0x95, 0x3F, //   Report Count (63)
+    0xB1, 0x02, //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
     0xC0, // End Collection
-    // 405 bytes
+    // 437 bytes
 };
-static_assert(sizeof(desc_hid_report_dse) == 405);
+static_assert(sizeof(desc_hid_report_dse) == 437);
 
 #ifdef ENABLE_WAKE_HID
 // 41-byte boot-keyboard report descriptor (modifier byte + reserved + 6 keycodes,

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -146,6 +146,7 @@ extern "C" void tud_mount_cb(void) {
     WAKE_DBG("tud_mount_cb state=%s", wake_state_name(state));
     host_suspended = false;
     host_resumed_event = true;
+    config_note_usb_enumerated_layout();
 }
 
 void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -1,6 +1,8 @@
 //
 // Created by awalol on 2026/4/30.
 //
+// Wake-on-PS: controller button -> USB remote wakeup -> forward DS5 gamepad
+// input to the host. No keyboard interface or synthetic key injection.
 
 #include "wake.h"
 
@@ -15,19 +17,17 @@
 #include "pico/time.h"
 #include "ps_shortcut.h"
 #include "config.h"
+#include "state_mgr.h"
+#include "audio.h"
 
+extern bool spk_active;
 
-#define WAKE_KBD_INSTANCE     1
-#define WAKE_KEYCODE_F15      0x68
-// Post-resume timings tuned for "wake-and-resleep" Windows behavior: the host
-// resumes USB, but if no HID input is consumed during the brief wake window
-// the system can re-suspend within ~1 s. Bigger settles + a second F15 give
-// Windows multiple polling cycles to pick the keystroke up.
-#define WAKE_SETTLE_US        150000   // 150 ms — let host finish USB re-init
-#define WAKE_KEY_HOLD_US       80000   // 80 ms keydown -> keyup gap
-#define WAKE_KEY_UP_SETTLE_US 200000   // 200 ms between attempts (or before DONE)
+#define WAKE_GAMEPAD_REPORT_LEN 63
+// Post-resume settle: let the host finish USB re-init before the gamepad report.
+#define WAKE_SETTLE_US          150000
+#define WAKE_REPORT_RETRY_US    200000
 #define WAKE_REQUEST_TIMEOUT_US 5000000
-#define WAKE_KEY_ATTEMPTS     2
+#define WAKE_REPORT_ATTEMPTS    2
 
 #ifdef WAKE_DEBUG
 #  define WAKE_DBG(fmt, ...) printf("[wake] " fmt "\n", ##__VA_ARGS__)
@@ -36,9 +36,7 @@ static const char *wake_state_name(int s) {
     case 0: return "IDLE";
     case 1: return "PENDING_PRESS";
     case 2: return "REQUESTED";
-    case 3: return "KEY_DOWN";
-    case 4: return "KEY_UP_SENT";
-    case 5: return "DONE";
+    case 3: return "DONE";
     default: return "?";
     }
 }
@@ -50,8 +48,6 @@ typedef enum {
     WAKE_IDLE,
     WAKE_PENDING_PRESS,
     WAKE_REQUESTED,
-    WAKE_KEY_DOWN,
-    WAKE_KEY_UP_SENT,
     WAKE_DONE,
 } wake_state_t;
 
@@ -60,7 +56,9 @@ static volatile bool host_suspended = false;
 static volatile bool host_resumed_event = false;
 static wake_state_t state = WAKE_IDLE;
 static uint64_t state_entered_us = 0;
-static uint8_t key_attempts = 0;
+static uint8_t report_attempts = 0;
+static uint8_t pending_gamepad[WAKE_GAMEPAD_REPORT_LEN]{};
+static bool pending_gamepad_valid = false;
 // Last-seen DualSense button bytes. Idle defaults: byte 7 = 0x08 (D-pad
 // released), bytes 8 / 9 = 0 (no shoulders, no PS / touchpad / mute).
 static uint8_t prev_b7 = 0x08;
@@ -72,12 +70,23 @@ static void enter_state(wake_state_t s) {
     state_entered_us = time_us_64();
 }
 
-static void request_host_wake(const char *reason) {
+static void stash_gamepad_report(const uint8_t *hid_input, uint16_t len) {
+    const uint16_t copy_len = len < WAKE_GAMEPAD_REPORT_LEN ? len : WAKE_GAMEPAD_REPORT_LEN;
+    memcpy(pending_gamepad, hid_input, copy_len);
+    if (copy_len < WAKE_GAMEPAD_REPORT_LEN) {
+        memset(pending_gamepad + copy_len, 0, WAKE_GAMEPAD_REPORT_LEN - copy_len);
+    }
+    pending_gamepad_valid = true;
+}
+
+static void request_host_wake(const char *reason, const uint8_t *hid_input, uint16_t len) {
+    if (hid_input != nullptr && len > 0) {
+        stash_gamepad_report(hid_input, len);
+    }
+
     bool ok = tud_remote_wakeup();
 
-    // Linux quirk: Sometimes Linux fails to set the REMOTE_WAKEUP feature
-    // flag before the second suspend, causing TinyUSB to refuse to wake.
-    // If we are suspended but ok is false, we force the wake signal.
+    // Linux quirk: host may not set REMOTE_WAKEUP before a repeat suspend.
     if (!ok && host_suspended) {
         WAKE_DBG("%s: tud_remote_wakeup()=0 but suspended. Forcing DCD wake.", reason);
         dcd_remote_wakeup(0);
@@ -88,6 +97,7 @@ static void request_host_wake(const char *reason) {
         critical_section_enter_blocking(&wake_cs);
         state = WAKE_REQUESTED;
         state_entered_us = time_us_64();
+        report_attempts = 0;
         critical_section_exit(&wake_cs);
         WAKE_DBG("%s -> REQUESTED", reason);
     }
@@ -110,17 +120,22 @@ void wake_init(void) {
 extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
     WAKE_DBG("tud_suspend_cb remote_wakeup_en=%d prev_state=%s",
              (int)remote_wakeup_en, wake_state_name(state));
+    // Required: tell the controller to drop BT during host USB suspend. Wake
+    // is handled on the next controller button press -> BT reconnect ->
+    // wake_on_bt_connect() / wake_on_bt_input().
     bt_power_off_controller();
     host_suspended = true;
     host_resumed_event = false;
-    
-    // Unconditionally re-arm on suspend. If a previous wake attempt hung
-    // (e.g. Linux ignored a keystroke and left the endpoint busy forever),
-    // we must abort and reset so the NEXT wake attempt can trigger.
+    if (get_config().enable_wake) {
+        state_note_usb_suspend();
+    }
+
     state = WAKE_PENDING_PRESS;
     state_entered_us = time_us_64();
-    prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
-    key_attempts = 0;
+    prev_b7 = 0x08;
+    prev_b8 = 0x00;
+    prev_b9 = 0x00;
+    report_attempts = 0;
     WAKE_DBG("-> PENDING_PRESS");
 }
 
@@ -132,7 +147,10 @@ void wake_on_bt_connect(void) {
     critical_section_exit(&wake_cs);
 
     if (should_wake) {
-        request_host_wake("BT reconnect while suspended");
+        request_host_wake("BT reconnect while suspended", nullptr, 0);
+    }
+    if (bt_is_connected() && spk_active) {
+        audio_resync_speaker_path();
     }
 }
 
@@ -140,6 +158,17 @@ extern "C" void tud_resume_cb(void) {
     WAKE_DBG("tud_resume_cb state=%s", wake_state_name(state));
     host_suspended = false;
     host_resumed_event = true;
+    if (get_config().enable_wake) {
+        state_on_host_usb_resume();
+    }
+    // Re-sync controller audio after USB resume (BT may reconnect shortly after).
+    if (bt_is_connected()) {
+        if (spk_active) {
+            audio_resync_speaker_path();
+        } else {
+            update_mic_status();
+        }
+    }
 }
 
 extern "C" void tud_mount_cb(void) {
@@ -152,26 +181,7 @@ extern "C" void tud_mount_cb(void) {
 void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
     if (!get_config().enable_wake) return;
     if (len < 10) return;
-    // DualSense BT 0x31 input report layout (after main.cpp's `data + 3` skip):
-    //   byte 7 low nibble: D-pad direction (0x08 idle); high nibble: face buttons
-    //   byte 8: L1, R1, L2 click, R2 click, share, options, L3, R3
-    //   byte 9: PS (bit 0), touchpad-click (bit 1), mute (bit 2)
-    //
-    // We trigger on ANY change in those three button bytes, not strictly on
-    // the PS bit. Reasons:
-    //   1. The DualSense's BT radio enters a low-power sniff mode after a
-    //      period of inactivity. The PS button alone often does not wake
-    //      the radio out of sniff -- shoulder buttons reliably do. So the
-    //      first BT report after S3 is most likely whichever button the
-    //      user happened to press to wake the radio. PS itself counts as
-    //      "any button" too, so the single-press UX still works.
-    //   2. We additionally call tud_remote_wakeup() speculatively even from
-    //      WAKE_IDLE / WAKE_DONE state. TinyUSB returns true only when the
-    //      host actually USB-suspended the bus; otherwise it's a no-op. This
-    //      protects against the case where tud_suspend_cb didn't fire (e.g.
-    //      a hub between the host and the dongle masking the suspend signal
-    //      from downstream). On success the FSM transitions to REQUESTED and
-    //      proceeds with the keystroke as normal.
+
     const uint8_t b7 = hid_input[7];
     const uint8_t b8 = hid_input[8];
     const uint8_t b9 = hid_input[9];
@@ -179,20 +189,39 @@ void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
     critical_section_enter_blocking(&wake_cs);
     const bool changed = (b7 != prev_b7) || (b8 != prev_b8) || (b9 != prev_b9);
     const bool armable = (state == WAKE_IDLE || state == WAKE_DONE || state == WAKE_PENDING_PRESS);
-    prev_b7 = b7; prev_b8 = b8; prev_b9 = b9;
+    prev_b7 = b7;
+    prev_b8 = b8;
+    prev_b9 = b9;
     critical_section_exit(&wake_cs);
 
     if (changed && armable) {
-        request_host_wake("button event");
+        request_host_wake("button event", hid_input, len);
     }
 }
 
 void wake_on_bt_disconnect(void) {
     critical_section_enter_blocking(&wake_cs);
     state = WAKE_IDLE;
-    prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
+    prev_b7 = 0x08;
+    prev_b8 = 0x00;
+    prev_b9 = 0x00;
+    pending_gamepad_valid = false;
     critical_section_exit(&wake_cs);
     ps_shortcut_reset();
+}
+
+static bool push_gamepad_wake_report(void) {
+    if (!pending_gamepad_valid) {
+        return true;
+    }
+    if (!tud_hid_ready()) {
+        return false;
+    }
+    if (!tud_hid_report(0x01, pending_gamepad, WAKE_GAMEPAD_REPORT_LEN)) {
+        return false;
+    }
+    WAKE_DBG("sent gamepad wake report (attempt %d/%d)", report_attempts + 1, WAKE_REPORT_ATTEMPTS);
+    return true;
 }
 
 void wake_task(void) {
@@ -211,94 +240,49 @@ void wake_task(void) {
             return;
 
         case WAKE_REQUESTED: {
-            if (host_resumed_event || !host_suspended) {
-                host_resumed_event = false;
-                if (now - entered < WAKE_SETTLE_US) return;
-                if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) {
-#ifdef WAKE_DEBUG
-                    static uint64_t last_log = 0;
-                    if (now - last_log > 1000000) {
-                        WAKE_DBG("REQUESTED waiting: hid_n_ready=0 (heartbeat 1Hz)");
-                        last_log = now;
-                    }
-#endif
-                    return;
-                }
-                uint8_t rpt[8] = { 0, 0, WAKE_KEYCODE_F15, 0, 0, 0, 0, 0 };
-                const bool sent = tud_hid_n_report(WAKE_KBD_INSTANCE, 0, rpt, sizeof(rpt));
-                WAKE_DBG("REQUESTED: sent keydown 0x%02X -> %d", WAKE_KEYCODE_F15, (int)sent);
-                if (sent) {
+            if (!(host_resumed_event || !host_suspended)) {
+                if (now - entered > WAKE_REQUEST_TIMEOUT_US) {
+                    WAKE_DBG("REQUESTED timeout 5s -> DONE");
                     critical_section_enter_blocking(&wake_cs);
-                    enter_state(WAKE_KEY_DOWN);
+                    enter_state(WAKE_DONE);
                     critical_section_exit(&wake_cs);
                 }
-            } else if (now - entered > WAKE_REQUEST_TIMEOUT_US) {
-                WAKE_DBG("REQUESTED timeout 5s -> DONE (no resume signaling; may have already woken)");
-                critical_section_enter_blocking(&wake_cs);
-                enter_state(WAKE_DONE);
-                critical_section_exit(&wake_cs);
+                return;
             }
-            return;
-        }
 
-        case WAKE_KEY_DOWN: {
-            if (now - entered < WAKE_KEY_HOLD_US) return;
-            if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) {
+            host_resumed_event = false;
+            if (now - entered < WAKE_SETTLE_US) {
+                return;
+            }
+
+            if (report_attempts > 0 && now - entered < WAKE_REPORT_RETRY_US) {
+                return;
+            }
+
+            if (!push_gamepad_wake_report()) {
 #ifdef WAKE_DEBUG
                 static uint64_t last_log = 0;
                 if (now - last_log > 1000000) {
-                    WAKE_DBG("KEY_DOWN waiting: hid_n_ready=0 (heartbeat 1Hz)");
+                    WAKE_DBG("REQUESTED waiting: tud_hid_ready/report (heartbeat 1Hz)");
                     last_log = now;
                 }
 #endif
                 return;
             }
-            uint8_t up[8] = { 0 };
-            const bool sent = tud_hid_n_report(WAKE_KBD_INSTANCE, 0, up, sizeof(up));
-            WAKE_DBG("KEY_DOWN: sent keyup -> %d", (int)sent);
-            if (sent) {
-                critical_section_enter_blocking(&wake_cs);
-                enter_state(WAKE_KEY_UP_SENT);
-                critical_section_exit(&wake_cs);
-            }
-            return;
-        }
 
-        case WAKE_KEY_UP_SENT: {
-            if (now - entered < WAKE_KEY_UP_SETTLE_US) return;
-            key_attempts++;
-            if (key_attempts < WAKE_KEY_ATTEMPTS) {
-                // Retry: do NOT re-enter WAKE_REQUESTED (which gates on a
-                // fresh tud_resume_cb event). We already established the
-                // host woke once; just send another keydown directly. If the
-                // host has dipped back into suspend, tud_hid_n_ready will be
-                // false and we'll heartbeat from KEY_DOWN until it returns.
-                if (!tud_hid_n_ready(WAKE_KBD_INSTANCE)) {
-#ifdef WAKE_DEBUG
-                    static uint64_t last_log = 0;
-                    if (now - last_log > 1000000) {
-                        WAKE_DBG("KEY_UP_SENT retry waiting: hid_n_ready=0 (heartbeat 1Hz)");
-                        last_log = now;
-                    }
-#endif
-                    return;
-                }
-                uint8_t rpt[8] = { 0, 0, WAKE_KEYCODE_F15, 0, 0, 0, 0, 0 };
-                const bool sent = tud_hid_n_report(WAKE_KBD_INSTANCE, 0, rpt, sizeof(rpt));
-                WAKE_DBG("KEY_UP_SENT: retrying F15 (attempt %d/%d) -> %d",
-                         (int)key_attempts + 1, (int)WAKE_KEY_ATTEMPTS, (int)sent);
-                if (sent) {
-                    critical_section_enter_blocking(&wake_cs);
-                    enter_state(WAKE_KEY_DOWN);
-                    critical_section_exit(&wake_cs);
-                }
-            } else {
-                WAKE_DBG("KEY_UP_SENT settle done -> DONE");
+            report_attempts++;
+            if (report_attempts < WAKE_REPORT_ATTEMPTS) {
                 critical_section_enter_blocking(&wake_cs);
-                enter_state(WAKE_DONE);
-                key_attempts = 0;
+                state_entered_us = time_us_64();
                 critical_section_exit(&wake_cs);
+                return;
             }
+
+            critical_section_enter_blocking(&wake_cs);
+            pending_gamepad_valid = false;
+            enter_state(WAKE_DONE);
+            critical_section_exit(&wake_cs);
+            WAKE_DBG("gamepad wake complete -> DONE");
             return;
         }
     }


### PR DESCRIPTION
## Summary

- **BT (#171):** Passive reconnect — skip boot inquiry when a controller is already paired
- **Lights:** Gold idle bar after game exit; fix race when launching a game right after S3 wake
- **WebHID config:** F6–F9 reports for ds5-dev UI; deferred USB reconnect on Save
- **Wake:** Gamepad-only S3 wake (no F15 keyboard / no MS OS selective-suspend); speaker + haptics + in-game lights verified

## Testing — wake upgrade (required once)

Remove stale registry keys from older wake builds (**PowerShell as admin**):

```powershell
Get-ChildItem 'HKLM:\SYSTEM\CurrentControlSet\Enum\USB\VID_054C&PID_0CE6&MI_00','HKLM:\SYSTEM\CurrentControlSet\Enum\USB\VID_054C&PID_0CE6&MI_03' -ErrorAction SilentlyContinue | ForEach-Object {
  Remove-ItemProperty "$($_.PSPath)\Device Parameters" SelectiveSuspendEnabled -ErrorAction SilentlyContinue }
  
  Then flash firmware, Save wake config, test controller speaker + haptics in game.

Test plan

 Wake OFF/ON: speaker, haptics, game lightbar, post-game gold idle

 S3 wake → quick game launch → game-controlled lights

 Web config Connect/Save without feature-report errors