### PR TITLE
fix(usb): ride out hub-induced suspends; power off the controller independent of wake

### DIFF
--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -581,11 +581,11 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
 
         case HCI_EVENT_DISCONNECTION_COMPLETE: {
 #if !ENABLE_SERIAL
-            // Hide the USB device whenever no controller is paired (upstream
-            // behavior) -- UNLESS wake is enabled at runtime, where we must stay on
-            // the bus across controller power-cycles so tud_suspend_cb can later fire
-            // and tud_remote_wakeup() can signal a wake when the controller returns.
-            if (!get_config().enable_wake) {
+            // Hide the USB device when no controller is paired (upstream behavior), EXCEPT when
+            // wake is on (stay on the bus so a returning controller can signal a host wake) or
+            // while the host is suspended -- hiding then re-showing re-enumerates, and a USB
+            // re-connect wakes a sleeping host. Defer the hide until the host is awake.
+            if (!get_config().enable_wake && !tud_suspended()) {
                 tud_disconnect();
             }
 #endif
@@ -657,14 +657,15 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
                     // reads are gated until the snapshot is prepared.
                     dse_on_connect();
 #if !ENABLE_SERIAL
-                    tud_connect();
+                    // don't re-enumerate while the host is suspended -- it would wake a sleeping host
+                    if (!tud_suspended()) tud_connect();
 #endif
                 } else if (packet[0] == 0x02) {
                     printf("Connected DS5 Controller\n");
                     check_dse = false;
                     is_dse = false;
 #if !ENABLE_SERIAL
-                    tud_connect();
+                    if (!tud_suspended()) tud_connect();
 #endif
                 }
             }

--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -13,6 +13,7 @@
 #include "device/usbd.h"
 #include "pico/time.h"
 #include "audio.h"
+#include "wake.h"
 
 // spk_active (main.cpp) + audio_mic_active() (audio.cpp) are surfaced in the
 // 0xf9 feature report so the config UI can display the real gated mic/speaker
@@ -94,6 +95,7 @@ void pico_cmd_set(uint8_t report_id, uint8_t const *buffer, uint16_t bufsize) {
     }
     if (buffer[0] == 0x03) {
         printf("[CMD] Enter tud reconnect func\n");
+        wake_note_usb_reconnect();   // this disconnect is intentional, not a host sleep
         tud_disconnect();
         sleep_ms(150);
         tud_connect();

--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -196,6 +196,7 @@ void tud_hid_report_complete_cb(uint8_t instance, uint8_t const *report, uint16_
 
 void tud_suspend_cb(bool remote_wakeup_en) {
     printf("[USB PM] invoke tud_suspend_cb\n");
+    if (!get_config().enable_wake) return;   // wake off: leave the controller's BT alone on a USB suspend (see wake.cpp)
     bt_power_off_controller();
 }
 

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -28,6 +28,12 @@
 #define WAKE_KEY_UP_SETTLE_US 200000   // 200 ms between attempts (or before DONE)
 #define WAKE_REQUEST_TIMEOUT_US 5000000
 #define WAKE_KEY_ATTEMPTS     2
+#define WAKE_POWEROFF_DEBOUNCE_US 3000000  // 3s: only power off the controller after a
+                                           // sustained suspend (real sleep); ignore brief
+                                           // hub-induced suspends while the host is awake.
+#define WAKE_RECONNECT_GRACE_US   5000000  // 5s: after a deliberate USB reconnect, ignore the
+                                           // suspend it causes (it is not a host sleep).
+                                           // Cleared early when the device re-mounts.
 
 #ifdef WAKE_DEBUG
 #  define WAKE_DBG(fmt, ...) printf("[wake] " fmt "\n", ##__VA_ARGS__)
@@ -66,6 +72,10 @@ static uint8_t key_attempts = 0;
 static uint8_t prev_b7 = 0x08;
 static uint8_t prev_b8 = 0x00;
 static uint8_t prev_b9 = 0x00;
+// Debounced controller power-off: time of the pending suspend (0 = none pending).
+static volatile uint64_t suspend_at_us = 0;
+// During a deliberate USB reconnect, ignore the suspend it triggers until this time.
+static volatile uint64_t reconnect_until_us = 0;
 
 static void enter_state(wake_state_t s) {
     state = s;
@@ -107,13 +117,34 @@ void wake_init(void) {
     critical_section_init(&wake_cs);
 }
 
+// Called right before a deliberate USB reconnect (FUNC_RECONNECT): arm a grace window so the
+// suspend the reconnect causes is ignored, and drop any already-pending debounced power-off.
+void wake_note_usb_reconnect(void) {
+    reconnect_until_us = time_us_64() + WAKE_RECONNECT_GRACE_US;
+    suspend_at_us = 0;
+}
+
 extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
     WAKE_DBG("tud_suspend_cb remote_wakeup_en=%d prev_state=%s",
              (int)remote_wakeup_en, wake_state_name(state));
-    bt_power_off_controller();
+    // A deliberate Reconnect USB (FUNC_RECONNECT) tears the bus down and back up, which looks
+    // like a suspend but is not a host sleep -- ignore it so it cannot power off the controller.
+    // See wake_note_usb_reconnect().
+    if (time_us_64() < reconnect_until_us) {
+        WAKE_DBG("suspend during reconnect grace -> ignored");
+        return;
+    }
+    // The power-off runs on every genuine suspend, independent of enable_wake (battery-save for
+    // a real sleep/shutdown). A spurious hub suspend is filtered by the debounce below, not a
+    // gate -- it resumes and tud_resume_cb / tud_mount_cb cancel the pending power-off first.
+    // Do NOT gate this on enable_wake, or the controller stops powering off on shutdown.
+    suspend_at_us = time_us_64();
     host_suspended = true;
     host_resumed_event = false;
     
+    // Everything below is the wake-UP path (press a key to wake the host) -- enable_wake only.
+    if (!get_config().enable_wake) return;
+
     // Unconditionally re-arm on suspend. If a previous wake attempt hung
     // (e.g. Linux ignored a keystroke and left the endpoint busy forever),
     // we must abort and reset so the NEXT wake attempt can trigger.
@@ -140,12 +171,15 @@ extern "C" void tud_resume_cb(void) {
     WAKE_DBG("tud_resume_cb state=%s", wake_state_name(state));
     host_suspended = false;
     host_resumed_event = true;
+    suspend_at_us = 0;   // resumed before the debounce elapsed -> cancel the power-off
 }
 
 extern "C" void tud_mount_cb(void) {
     WAKE_DBG("tud_mount_cb state=%s", wake_state_name(state));
     host_suspended = false;
     host_resumed_event = true;
+    suspend_at_us = 0;
+    reconnect_until_us = 0;   // reconnect finished re-enumerating; end the grace early
 }
 
 void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
@@ -195,8 +229,21 @@ void wake_on_bt_disconnect(void) {
 }
 
 void wake_task(void) {
-    if (!get_config().enable_wake) return;
     const uint64_t now = time_us_64();
+
+    // Commit the deferred controller power-off once we have stayed suspended past the debounce
+    // window (a genuine host sleep/shutdown). Runs regardless of enable_wake -- it is a
+    // battery-save, not part of the wake-UP path. A transient hub suspend will already have
+    // been cancelled by tud_resume_cb / tud_mount_cb before this fires.
+    if (suspend_at_us != 0 && host_suspended &&
+        now - suspend_at_us >= WAKE_POWEROFF_DEBOUNCE_US) {
+        bt_power_off_controller();
+        suspend_at_us = 0;
+        WAKE_DBG("suspend debounce elapsed -> bt_power_off_controller()");
+    }
+
+    // The wake-UP FSM below only runs when wake is enabled.
+    if (!get_config().enable_wake) return;
 
     critical_section_enter_blocking(&wake_cs);
     const wake_state_t s = state;

--- a/src/wake.h
+++ b/src/wake.h
@@ -13,12 +13,14 @@ void wake_on_bt_connect(void);
 void wake_on_bt_input(const uint8_t *hid_input, uint16_t len);
 void wake_on_bt_disconnect(void);
 void wake_task(void);
+void wake_note_usb_reconnect(void);
 #else
 static inline void wake_init(void) {}
 static inline void wake_on_bt_connect(void) {}
 static inline void wake_on_bt_input(const uint8_t *, uint16_t) {}
 static inline void wake_on_bt_disconnect(void) {}
 static inline void wake_task(void) {}
+static inline void wake_note_usb_reconnect(void) {}
 #endif
 
 #endif //DS5_BRIDGE_WAKE_H


### PR DESCRIPTION
## Summary

Some USB hubs let the downstream bus go idle (no SOF) while the host is **awake**. The
dongle sees that as a USB suspend, and since 0.7.0 a suspend immediately powered off the
DualSense's BT — so behind those hubs the controller drops mid-connect or never connects.
Regression vs 0.6.0-hotfix; reported in #174 and #148.

This reworks the suspend handling so the controller link rides through transient hub
suspends, without weakening wake-on-PS.

## Root cause

`tud_suspend_cb()` called `bt_power_off_controller()` on **every** USB suspend. A hub that
briefly suspends a live bus therefore kills the controller's BT. The #174 symptom — *"DS LED
flashes for a few seconds then turns off, Pico LED keeps flashing"* — is the controller
connecting and then being powered off by the spurious suspend.

## What changed

- **Debounce the power-off.** Commit it only after the suspend persists past
  `WAKE_POWEROFF_DEBOUNCE_US` (3 s). A transient hub suspend resumes — `tud_resume_cb` /
  `tud_mount_cb` cancel the pending power-off — before it fires; a real sleep/shutdown
  outlasts the window and still powers off.

- **Exempt a deliberate Reconnect USB (`FUNC_RECONNECT`).** That command drops and re-adds
  the USB device, which looks like a suspend but isn't a host sleep. A grace window
  (`wake_note_usb_reconnect()`) makes the induced suspend ignored, so Reconnect USB no longer
  drops the controller — independent of the debounce length.

- **Run the power-off independent of `enable_wake`.** Powering the controller off on a real
  host sleep/shutdown is a battery-save, not part of the wake feature, so it no longer hides
  behind the wake toggle. `enable_wake` now gates only the wake-up keystroke. (The legacy
  non-wake build keeps the simple "skip when wake off" gate — it has no debounce to filter
  hub blips.)

- **Stay on the bus while the host is suspended.** Across a controller power-cycle during
  sleep, the dongle no longer hides and re-shows the USB device. A re-enumeration is a
  hotplug event that wakes a sleeping host — which must not happen when wake is off.

## Behavior

| Scenario | wake off | wake on |
|---|---|---|
| Direct connection | unchanged | unchanged |
| Flaky hub, host awake | rides through the spurious suspend | rides through |
| Reconnect USB | controller stays connected | controller stays connected |
| Host sleep / shutdown | controller powers off (battery save) | powers off; PS wakes the host |

## Testing

Verified on hardware against a USB 3.2 hub that reproduces the issue (the same class
reported in #148):

- **Wake off (default):** controller stays connected through the hub (previously dropped).
- **Reconnect USB:** no longer disconnects the controller.
- **Wake off + sleep:** the controller powering off and reconnecting during sleep no longer
  wakes the PC — and with wake off the descriptor advertises no remote-wakeup, so the device
  is genuinely inert.
- **Sleep / shutdown:** controller still powers off (battery save); with wake on, a PS press
  still wakes the host.

The 3 s debounce is the validated worst case on the tested hub; because Reconnect USB is
decoupled from it, the window can be widened for slower hubs without lengthening reconnect.

Fixes #174. Fixes #148.

Both are the same root cause — #148 was independently bisected to the wake-feature commit
200103c. Validated here on a USB 3.2 hub, the same class #148 reports. Different 3.2 hub
models can hold the suspend for different lengths, so if an unusually slow one still drops
at 3 s, the window is a single constant (WAKE_POWEROFF_DEBOUNCE_US) — bump it and reopen.
