### PR TITLE
fix(waveshare): stabilize RP2350B-Plus-W on real hardware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,16 @@ target_compile_definitions(ds5-bridge PRIVATE
         DISABLE_SPEAKER_PROC=${DISABLE_SPEAKER_PROC_VALUE}
 )
 
+if (WAVESHARE_RP2350B_PLUS_W_BUILD)
+    target_compile_definitions(ds5-bridge PRIVATE
+            # Hardware-validated low-flash persistent layout. Accesses near
+            # the end of the advertised 16 MiB device stall this board.
+            DS5_WAVESHARE_STABLE_RUNTIME=1
+            DS5_CONFIG_FLASH_OFFSET=0x003FC000
+            PICO_FLASH_BANK_STORAGE_OFFSET=0x003FD000
+    )
+endif ()
+
 # Wake-on-PS + Xbox Game Bar are now in the base firmware, gated at runtime by the
 # enable_wake / ps_shortcut_enabled config fields. ENABLE_WAKE_HID stays defined so
 # the wake/keyboard descriptors and TinyUSB capacity compile in; the interface and

--- a/boards/headers/waveshare_rp2350b_plus_w.h
+++ b/boards/headers/waveshare_rp2350b_plus_w.h
@@ -24,6 +24,15 @@ pico_board_cmake_set(PICO_DEFAULT_BOOT_STAGE2, boot2_w25q080)
 // --- RP2350 VARIANT ---
 #define PICO_RP2350A 0
 
+// LED1 is CYW43 GPIO0. LED2 is directly connected to RP2350B GPIO23.
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 23
+#endif
+
+#ifndef PICO_DEFAULT_LED_PIN_INVERTED
+#define PICO_DEFAULT_LED_PIN_INVERTED 0
+#endif
+
 // --- UART ---
 #ifndef PICO_DEFAULT_UART
 #define PICO_DEFAULT_UART 0
@@ -71,7 +80,7 @@ pico_board_cmake_set(PICO_DEFAULT_BOOT_STAGE2, boot2_w25q080)
 #define PICO_FLASH_SPI_CLKDIV 2
 #endif
 
-// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (4 * 1024 * 1024)
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (16 * 1024 * 1024))
 #ifndef PICO_FLASH_SIZE_BYTES
 #define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
 #endif

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <algorithm>
 #include "bt.h"
 #include <queue>
 #include <unordered_map>
@@ -25,6 +26,7 @@
 #if ENABLE_BATT_LED
 #include "battery_led.h"
 #endif
+#include "pico/critical_section.h"
 #if PICO_RP2350
 #include "hardware/regs/sio.h"
 #endif
@@ -76,6 +78,98 @@ struct send_element {
     uint8_t data[672];
     size_t len;
 };
+
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+constexpr uint16_t kFeatureCachePayloadMax = 64;
+
+struct FeatureCacheEntry {
+    uint8_t data[kFeatureCachePayloadMax];
+    uint8_t size;
+    bool ready;
+};
+
+struct control_send_element {
+    uint8_t data[128];
+    uint16_t len;
+};
+
+FeatureCacheEntry fixed_feature_cache[256]{};
+critical_section_t fixed_feature_cache_cs;
+queue_t control_send_fifo;
+
+static void bt_feature_cache_clear() {
+    critical_section_enter_blocking(&fixed_feature_cache_cs);
+    for (auto &entry : fixed_feature_cache) {
+        entry.size = 0;
+        entry.ready = false;
+    }
+    critical_section_exit(&fixed_feature_cache_cs);
+}
+
+static void bt_feature_cache_store(const uint8_t report_id,
+                                   const uint8_t *payload,
+                                   const uint16_t payload_size) {
+    const uint8_t copy_size = static_cast<uint8_t>(
+        std::min<uint16_t>(payload_size, kFeatureCachePayloadMax));
+    critical_section_enter_blocking(&fixed_feature_cache_cs);
+    auto &entry = fixed_feature_cache[report_id];
+    memcpy(entry.data, payload, copy_size);
+    if (copy_size < sizeof(entry.data)) {
+        memset(entry.data + copy_size, 0, sizeof(entry.data) - copy_size);
+    }
+    entry.size = copy_size;
+    entry.ready = true;
+    critical_section_exit(&fixed_feature_cache_cs);
+}
+
+void bt_feature_cache_init_before_tusb() {
+    critical_section_init(&fixed_feature_cache_cs);
+    bt_feature_cache_clear();
+}
+
+uint16_t bt_copy_cached_feature(const uint8_t report_id,
+                                uint8_t *buffer,
+                                const uint16_t requested_length) {
+    const uint16_t fallback_length =
+        std::min<uint16_t>(requested_length, kFeatureCachePayloadMax);
+    uint8_t cached_size = 0;
+    bool ready = false;
+
+    critical_section_enter_blocking(&fixed_feature_cache_cs);
+    const auto &entry = fixed_feature_cache[report_id];
+    ready = entry.ready;
+    cached_size = entry.size;
+    if (ready) {
+        memcpy(buffer, entry.data,
+               std::min<uint16_t>(requested_length, cached_size));
+    }
+    critical_section_exit(&fixed_feature_cache_cs);
+
+    if (ready) {
+        return std::min<uint16_t>(requested_length, cached_size);
+    }
+
+    // Never wait, allocate or initiate L2CAP from a USB control callback.
+    memset(buffer, 0, fallback_length);
+    return fallback_length;
+}
+
+static bool bt_queue_control(const uint8_t *data, const uint16_t len) {
+    if (hid_control_cid == 0 || len > sizeof(control_send_element::data)) {
+        return false;
+    }
+    control_send_element packet{};
+    packet.len = len;
+    memcpy(packet.data, data, len);
+    if (!queue_try_add(&control_send_fifo, &packet)) {
+        return false;
+    }
+    if (queue_get_level(&control_send_fifo) == 1) {
+        l2cap_request_can_send_now_event(hid_control_cid);
+    }
+    return true;
+}
+#endif
 
 absolute_time_t inactive_time = 0; // 手柄长时间静默
 
@@ -147,6 +241,9 @@ void bt_l2cap_init() {
 
 int bt_init() {
     queue_init(&send_fifo, sizeof(send_element), 10);
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    queue_init(&control_send_fifo, sizeof(control_send_element), 10);
+#endif
 
     bt_l2cap_init();
 
@@ -596,7 +693,7 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
         }
 
         case HCI_EVENT_DISCONNECTION_COMPLETE: {
-#if !ENABLE_SERIAL
+#if !ENABLE_SERIAL && !defined(DS5_WAVESHARE_STABLE_RUNTIME)
             // Hide the USB device when no controller is paired (upstream behavior), EXCEPT when
             // wake is on (stay on the bus so a returning controller can signal a host wake) or
             // while the host is suspended -- hiding then re-showing re-enumerates, and a USB
@@ -617,6 +714,11 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             gpio_on_disconnect();
             while (queue_try_remove(&send_fifo, NULL)) {
             }
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+            while (queue_try_remove(&control_send_fifo, NULL)) {
+            }
+            bt_feature_cache_clear();
+#endif
             cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
 #if ENABLE_BATT_LED
             battery_led_on_disconnect();
@@ -649,6 +751,9 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
             bt_data_callback(INTERRUPT, packet, size);
 
             // 静默检测
+            if (size < 13) {
+                return;
+            }
             if (!(packet[2] & 1) || get_config().inactive_time == 0) {
                 return;
             }
@@ -667,15 +772,18 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
                 bt_disconnect();
             }
         } else if (channel == hid_control_cid) {
-            if (packet[0] == 0xA3) {
+            if (size >= 2 && packet[0] == 0xA3) {
                 const uint8_t report_id = packet[1];
                 feature_data[report_id].assign(packet + 2, packet + size);
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+                bt_feature_cache_store(report_id, packet + 2, size - 2);
+#endif
 #if ENABLE_VERBOSE
                 printf("[L2CAP] Stored Feature Report 0x%02X, len=%u\n", report_id, size - 2);
                 printf("[L2CAP] HID Control data len=%u\n", size);
                 printf_hexdump(packet, size);
 #endif
-                if (report_id == 0x20) {
+                if (report_id == 0x20 && size >= 24) {
                     if (packet[23] == 0x44) {
                         printf("Connected DSE Controller\n");
                         is_dse = true;
@@ -688,12 +796,11 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
                         printf("Connected DS5 Controller\n");
                         is_dse = false;
                     }
-#if !ENABLE_SERIAL
+#if !ENABLE_SERIAL && !defined(DS5_WAVESHARE_STABLE_RUNTIME)
                     if (!tud_suspended()) tud_connect();
 #endif
                 }
             }
-
             dse_on_control_packet(packet, size);
             bt_data_callback(CONTROL, packet, size);
         } else {
@@ -808,7 +915,27 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
 
         case L2CAP_EVENT_CAN_SEND_NOW: {
             // printf("[L2CAP] L2CAP_EVENT_CAN_SEND_NOW\n");
-
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+            const uint16_t can_send_cid =
+                l2cap_event_can_send_now_get_local_cid(packet);
+            if (can_send_cid == hid_control_cid) {
+                control_send_element control_packet{};
+                if (queue_try_remove(&control_send_fifo, &control_packet)) {
+                    const uint8_t status = l2cap_send(
+                        hid_control_cid, control_packet.data, control_packet.len);
+                    if (status != 0) {
+                        printf("[L2CAP control] Send error: 0x%02X\n", status);
+                    }
+                }
+                if (!queue_is_empty(&control_send_fifo)) {
+                    l2cap_request_can_send_now_event(hid_control_cid);
+                }
+                break;
+            }
+            if (can_send_cid != hid_interrupt_cid) {
+                break;
+            }
+#endif
             send_element send_packet{};
             if (queue_try_remove(&send_fifo, &send_packet)) {
                 const uint8_t status = l2cap_send(hid_interrupt_cid, send_packet.data, send_packet.len);
@@ -831,7 +958,11 @@ uint16_t bt_control_cid() {
 
 void bt_control_send(const uint8_t *data, uint16_t len) {
     if (hid_control_cid != 0) {
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+        bt_queue_control(data, len);
+#else
         l2cap_send(hid_control_cid, const_cast<uint8_t *>(data), len);
+#endif
     }
 }
 
@@ -872,7 +1003,11 @@ vector<uint8_t> get_feature_data(uint8_t reportId, uint16_t len) {
     ) {
         if (hid_control_cid != 0) {
             uint8_t get_feature[] = {0x43, reportId};
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+            bt_queue_control(get_feature, sizeof(get_feature));
+#else
             l2cap_send(hid_control_cid, get_feature, sizeof(get_feature));
+#endif
 #if ENABLE_VERBOSE
             printf("[L2CAP] Requesting Get Feature Report 0x%02X\n", reportId);
 #endif
@@ -888,7 +1023,11 @@ void set_feature_data(uint8_t reportId, uint8_t *data, uint16_t len) {
         get_feature[1] = reportId;
         memcpy(get_feature + 2, data, len);
         fill_feature_report_checksum(get_feature + 1, len + 1);
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+        bt_queue_control(get_feature, len + 2);
+#else
         l2cap_send(hid_control_cid, get_feature, len + 2);
+#endif
 #if ENABLE_VERBOSE
         printf("[L2CAP] Requesting Set Feature Report 0x%02X\n", reportId);
         printf_hexdump(get_feature, len + 2);
@@ -899,6 +1038,9 @@ void set_feature_data(uint8_t reportId, uint8_t *data, uint16_t len) {
 
 void init_feature() {
     feature_data.clear();
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    bt_feature_cache_clear();
+#endif
     get_feature_data(0x09, 20);
     get_feature_data(0x20, 64);
     get_feature_data(0x22, 64);

--- a/src/bt.h
+++ b/src/bt.h
@@ -28,6 +28,10 @@ void bt_set_scan_active();
 void dse_unlock_task();
 bool bt_dse_profiles_ready();
 void bt_write(const uint8_t *data, uint16_t len);
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+void bt_feature_cache_init_before_tusb();
+uint16_t bt_copy_cached_feature(uint8_t report_id, uint8_t *buffer, uint16_t requested_length);
+#endif
 void bt_get_signal_strength(int8_t *rssi);
 std::vector<uint8_t> get_feature_data(uint8_t reportId,uint16_t len);
 void init_feature();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -17,7 +17,12 @@
 
 constexpr uint32_t CONFIG_MAGIC = 0x66ccff00;
 constexpr uint16_t CONFIG_VERSION = 5; // 如果想要强制重置配置，再更新 CONFIG_VERSION。
-constexpr uint32_t CONFIG_FLASH_OFFSET = PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE;
+#ifdef DS5_CONFIG_FLASH_OFFSET
+#define DS5_CONFIG_FLASH_OFFSET_EXPLICIT 1
+#else
+#define DS5_CONFIG_FLASH_OFFSET (PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE)
+#endif
+constexpr uint32_t CONFIG_FLASH_OFFSET = DS5_CONFIG_FLASH_OFFSET;
 static Config config{};
 bool is_dse = false;
 
@@ -26,6 +31,10 @@ bool is_dse = false;
 static_assert(sizeof(Config) <= FLASH_PAGE_SIZE);
 // 配置区起始地址必须按 flash sector 对齐。
 static_assert(CONFIG_FLASH_OFFSET % FLASH_SECTOR_SIZE == 0);
+#if defined(DS5_CONFIG_FLASH_OFFSET_EXPLICIT) && defined(PICO_FLASH_BANK_STORAGE_OFFSET)
+static_assert(CONFIG_FLASH_OFFSET + FLASH_SECTOR_SIZE <= PICO_FLASH_BANK_STORAGE_OFFSET,
+              "Config sector overlaps BTstack flash banks");
+#endif
 
 uint32_t calc_config_crc(const Config &con) {
     return crc32(reinterpret_cast<const uint8_t *>(&con.body), sizeof(Config_body));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <cstdio>
+#include <algorithm>
 #include "bsp/board_api.h"
 #include "bt.h"
 #include "button_functions.h"
@@ -21,6 +22,7 @@
 #include "hardware/vreg.h"
 #include "hardware/watchdog.h"
 #include "pico/cyw43_arch.h"
+#include "pico/time.h"
 #if ENABLE_SERIAL
 #include "pico/stdio_usb.h"
 #endif
@@ -34,6 +36,7 @@
 
 // Pico SDK speciifically for waiting on conditions
 #include "pico/critical_section.h"
+#include "pico/util/queue.h"
 
 uint8_t reportSeqCounter = 0;
 uint8_t packetCounter = 0;
@@ -53,7 +56,146 @@ uint8_t interrupt_in_data[63] = {
 critical_section_t report_cs;
 volatile bool report_dirty = false;
 
+static bool handle_output_report(const uint8_t *data, const uint16_t size) {
+    // A standard DualSense USB report 0x02 contains 47 state bytes, while
+    // SetStateData also covers the controller's larger 63-byte internal/Edge
+    // state. Accept the complete USB payload and zero-initialize the fields
+    // which are not present instead of dropping every standard output report.
+    constexpr uint16_t kUsbSetStatePayloadSize = 47;
+    if (size < kUsbSetStatePayloadSize) {
+        return false;
+    }
+
+    SetStateData state{};
+    memcpy(&state, data, std::min<uint16_t>(size, sizeof(state)));
+
+    const auto &config = get_config();
+    if (config.trigger_reduce > 0) {
+        state.AllowMotorPowerLevel = 1;
+        state.TriggerMotorPowerReduction = config.trigger_reduce;
+    }
+    if (config.speaker_gain > 0) {
+        state.AllowAudioControl2 = 1;
+        state.SpeakerCompPreGain = config.speaker_gain;
+    }
+    if (config.mic_select != 0) {
+        state.AllowAudioControl = 1;
+        state.MicSelect = config.mic_select;
+    }
+    if (config.lock_volume) {
+        state.AllowHeadphoneVolume = 0;
+        state.AllowMicVolume = 0;
+        state.AllowSpeakerVolume = 0;
+        state.AllowAudioMute = 0;
+        state.AllowMuteLight = 0;
+    }
+
+    uint8_t output_data[78]{};
+    output_data[0] = 0x31;
+    output_data[1] = static_cast<uint8_t>(reportSeqCounter << 4);
+    reportSeqCounter = static_cast<uint8_t>((reportSeqCounter + 1) & 0x0f);
+    output_data[2] = 0x10;
+    memcpy(output_data + 3, &state, sizeof(state));
+    bt_write(output_data, sizeof(output_data));
+#if ENABLE_VERBOSE
+    printf_hexdump(output_data, sizeof(output_data));
+#endif
+    return true;
+}
+
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+struct UsbSetReportWork {
+    uint8_t report_id;
+    hid_report_type_t report_type;
+    uint8_t size;
+    uint8_t data[64];
+};
+
+queue_t usb_set_report_queue;
+alignas(4) uint8_t usb_input_tx_buffer[63];
+
+static void usb_queues_init_before_tusb() {
+    queue_init(&usb_set_report_queue, sizeof(UsbSetReportWork), 4);
+}
+
+static void queue_usb_set_report(const uint8_t report_id,
+                                 const hid_report_type_t report_type,
+                                 const uint8_t *data,
+                                 const uint16_t size) {
+    UsbSetReportWork work{};
+    work.report_id = report_id;
+    work.report_type = report_type;
+    work.size = static_cast<uint8_t>(
+        std::min<uint16_t>(size, sizeof(work.data)));
+    memcpy(work.data, data, work.size);
+
+    if (!queue_try_add(&usb_set_report_queue, &work)) {
+        UsbSetReportWork stale{};
+        queue_try_remove(&usb_set_report_queue, &stale);
+        queue_try_add(&usb_set_report_queue, &work);
+    }
+}
+
+static void usb_set_report_task() {
+    UsbSetReportWork work{};
+    while (queue_try_remove(&usb_set_report_queue, &work)) {
+        if (is_pico_cmd(work.report_id)) {
+            pico_cmd_set(work.report_id, work.data, work.size);
+            continue;
+        }
+
+        if (work.report_type == HID_REPORT_TYPE_OUTPUT &&
+            work.report_id == 0x02) {
+            handle_output_report(work.data, work.size);
+            continue;
+        }
+
+        if (work.report_type == HID_REPORT_TYPE_FEATURE &&
+            (work.report_id == 0x80 || work.report_id == 0x60 ||
+             work.report_id == 0x62 || work.report_id == 0x61)) {
+            set_feature_data(work.report_id, work.data, work.size);
+        }
+    }
+}
+#endif
+
 void __not_in_flash_func(interrupt_loop)() {
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    if (!tud_mounted() || tud_suspended() || !tud_hid_ready()) {
+        return;
+    }
+
+    const uint8_t polling_mode = get_config().polling_rate_mode;
+    const uint32_t now = to_ms_since_boot(get_absolute_time());
+    static uint32_t next_send_ms = 0;
+    if (polling_mode != 2 && static_cast<int32_t>(now - next_send_ms) < 0) {
+        return;
+    }
+
+    bool should_send = polling_mode != 2;
+    critical_section_enter_blocking(&report_cs);
+    if (report_dirty || polling_mode != 2) {
+        memcpy(usb_input_tx_buffer, interrupt_in_data, sizeof(usb_input_tx_buffer));
+        should_send = true;
+        report_dirty = false;
+    }
+    critical_section_exit(&report_cs);
+
+    if (!should_send) {
+        return;
+    }
+    if (tud_hid_report(0x01, usb_input_tx_buffer,
+                       sizeof(usb_input_tx_buffer))) {
+        if (polling_mode != 2) {
+            next_send_ms = now + (polling_mode == 1 ? 2u : 4u);
+        }
+    } else {
+        critical_section_enter_blocking(&report_cs);
+        report_dirty = true;
+        critical_section_exit(&report_cs);
+    }
+    return;
+#else
     if (!tud_hid_ready()) return;
 
     // TODO: Refactor for better code reuse
@@ -89,11 +231,12 @@ void __not_in_flash_func(interrupt_loop)() {
             critical_section_exit(&report_cs);
         }
     }
+#endif
 }
 
 void __not_in_flash_func(on_bt_data)(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
     // printf("[Main] BT data callback: channel=%u len=%u\n", channel, len);
-    if (channel == INTERRUPT && len > 2 && data[1] == 0x31) {
+    if (channel == INTERRUPT && len >= 66 && data[1] == 0x31) {
         // Mic audio: controller signals mic payload via bit1 of data[2];
         // the opus-encoded mic frame starts at data+4.
         if ((data[2] >> 1) & 1) {
@@ -131,6 +274,7 @@ void __not_in_flash_func(on_bt_data)(CHANNEL_TYPE channel, uint8_t *data, uint16
         ps_shortcut_tick(data + 3, len - 3);
         #endif
 
+#if !defined(DS5_WAVESHARE_STABLE_RUNTIME)
         if (get_config().polling_rate_mode != 2) {
             memcpy(interrupt_in_data, data + 3, 63);
 #if ENABLE_BATT_LED
@@ -138,6 +282,7 @@ void __not_in_flash_func(on_bt_data)(CHANNEL_TYPE channel, uint8_t *data, uint16
 #endif
             return;
         }
+#endif
 
         // We add the critical section here to avoid any race conditions when writing to the interrupt_in_data buffer,
         // which is shared between the main loop and this callback.
@@ -178,6 +323,17 @@ uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t
     if (is_pico_cmd(report_id)) {
         return pico_cmd_get(report_id, buffer, reqlen);
     }
+
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    if (report_type == HID_REPORT_TYPE_FEATURE) {
+        // Edge profiles are prefetched by dse_task(). NAK until the bounded
+        // main-loop job finishes instead of returning a cacheable zero page.
+        if (dse_is_profile_report(report_id) && !dse_profiles_ready()) {
+            return 0;
+        }
+        return bt_copy_cached_feature(report_id, buffer, reqlen);
+    }
+#endif
 
     // DSE profiles: while the unlock + prefetch is still in progress, return 0
     // (NAK) for profile reads so the PS app retries rather than caching an
@@ -222,6 +378,22 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
         return;
     }
 #endif
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    if (itf != 0) {
+        return;
+    }
+
+    // Interrupt OUT retains report ID 0x02 in the buffer; control SET_REPORT
+    // supplies it separately. Only copy here: state, heap and Bluetooth work
+    // must run later in the main loop, outside the USB callback.
+    if (report_type == HID_REPORT_TYPE_OUTPUT &&
+        report_id == 0 && bufsize > 1 && buffer[0] == 0x02) {
+        queue_usb_set_report(0x02, report_type, buffer + 1, bufsize - 1);
+        return;
+    }
+    queue_usb_set_report(report_id, report_type, buffer, bufsize);
+    return;
+#else
     (void) itf;
     (void) report_id;
     (void) report_type;
@@ -240,40 +412,7 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
     if (report_id == 0) {
         switch (buffer[0]) {
             case 0x02: {
-                uint8_t outputData[78]{};
-                outputData[0] = 0x31;
-                outputData[1] = reportSeqCounter << 4;
-                reportSeqCounter = (reportSeqCounter + 1) & 0x0F;
-                outputData[2] = 0x10;
-                SetStateData state{};
-                memcpy(&state,buffer + 1,sizeof(SetStateData));
-
-                const auto &config = get_config();
-                if (config.trigger_reduce > 0) {
-                    state.AllowMotorPowerLevel = 1;
-                    state.TriggerMotorPowerReduction = config.trigger_reduce;
-                }
-                if (config.speaker_gain > 0) {
-                    state.AllowAudioControl2 = 1;
-                    state.SpeakerCompPreGain = config.speaker_gain;
-                }
-                if (config.mic_select != 0) {
-                    state.AllowAudioControl = 1;
-                    state.MicSelect = config.mic_select;
-                }
-                if (config.lock_volume) {
-                    state.AllowHeadphoneVolume = 0;
-                    state.AllowMicVolume = 0;
-                    state.AllowSpeakerVolume = 0;
-                    state.AllowAudioMute = 0;
-                    state.AllowMuteLight = 0;
-                }
-
-                memcpy(outputData + 3, &state, sizeof(SetStateData));
-                bt_write(outputData, sizeof(outputData));
-#if ENABLE_VERBOSE
-                printf_hexdump(outputData,sizeof(outputData));
-#endif
+                handle_output_report(buffer + 1, bufsize - 1);
                 break;
             }
         }
@@ -285,6 +424,7 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
         report_id == 0x61) {
         // set_feature_data(report_id, const_cast<uint8_t *>(buffer), bufsize);
     }
+#endif
 }
 
 int main() {
@@ -295,12 +435,18 @@ int main() {
 #endif
 
     board_init();
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+    // Windows can issue GET/SET requests immediately after tusb_init().
+    critical_section_init(&report_cs);
+    bt_feature_cache_init_before_tusb();
+    usb_queues_init_before_tusb();
+#endif
     tusb_rhport_init_t dev_init = {
         .role = TUSB_ROLE_DEVICE,
         .speed = TUSB_SPEED_FULL
     };
     tusb_init(BOARD_TUD_RHPORT, &dev_init);
-#if !ENABLE_SERIAL
+#if !ENABLE_SERIAL && !defined(DS5_WAVESHARE_STABLE_RUNTIME)
     sleep_ms(150);
     tud_disconnect();
 #endif
@@ -323,7 +469,7 @@ int main() {
     battery_led_init();
 #endif
 
-#if !ENABLE_SERIAL
+#if !ENABLE_SERIAL && !defined(DS5_WAVESHARE_STABLE_RUNTIME)
     if (watchdog_caused_reboot()) {
         printf("Rebooted by Watchdog!\n");
         // 当崩溃重启以后，闪三下灯
@@ -341,7 +487,9 @@ int main() {
 #endif
 
     // Initialize the critical section for the report buffer
+#if !defined(DS5_WAVESHARE_STABLE_RUNTIME)
     critical_section_init(&report_cs);
+#endif
     wake_init();
 
     config_load();
@@ -352,16 +500,19 @@ int main() {
 
     audio_init();
 
-#if !ENABLE_SERIAL
+#if !ENABLE_SERIAL && !defined(DS5_WAVESHARE_STABLE_RUNTIME)
     watchdog_enable(1000, true);
 #endif
 
     while (1) {
-#if !ENABLE_SERIAL
+#if !ENABLE_SERIAL && !defined(DS5_WAVESHARE_STABLE_RUNTIME)
         watchdog_update();
 #endif
         cyw43_arch_poll();
         tud_task();
+#if defined(DS5_WAVESHARE_STABLE_RUNTIME)
+        usb_set_report_task();
+#endif
         wake_task();
         audio_loop();
 #if ENABLE_DEBUG


### PR DESCRIPTION
## Summary

- Use a hardware-validated low-flash layout for persistent configuration and BTstack TLV storage on the Waveshare RP2350B-Plus-W.
- Keep USB mounted across Bluetooth connection transitions to prevent failed enumeration and unexpected host wake-ups.
- Move USB HID output processing out of TinyUSB callbacks and into the main loop.
- Serialize Bluetooth HID control transfers through L2CAP `CAN_SEND_NOW` events.
- Cache feature reports in fixed storage and gate HID input submissions on TinyUSB readiness.
- Safely parse the standard 47-byte DualSense USB output payload without requiring the controller's larger 63-byte internal state.

## Root cause

Testing on a physical Waveshare RP2350B-Plus-W showed that accesses near the end of the advertised 16 MiB flash could stall configuration loading and BTstack TLV initialization. Depending on the startup stage, this prevented Bluetooth pairing or caused Windows to report `VID_0000&PID_0002`.

The rebased implementation also exposed a report-size boundary issue: standard USB output report `0x02` contains 47 state bytes, while the internal `SetStateData` structure is 63 bytes. Requiring the full internal size caused rumble, lightbar, and adaptive-trigger reports to be discarded.

## Hardware validation

Validated on a physical Waveshare RP2350B-Plus-W with:

- Stable Windows enumeration as `VID_054C&PID_0CE6`
- Bluetooth pairing and reconnect
- Controller input
- Rumble and lightbar output
- Adaptive triggers
- Feature report `0x09`
- Native audio haptics
- Controller speaker audio
- Correct Windows speaker and microphone endpoints
- USB reconnects without `VID_0000&PID_0002`

The fix was first isolated on the `v0.7.2-hotfix` baseline, then rebased onto current `master` and retested on the same hardware.

## Build validation

Built successfully with:

- Pico SDK 2.3.0
- Pinned TinyUSB revision
- Arm GNU Toolchain 15.2.Rel1
- Waveshare RP2350B-Plus-W target
- Default RP2350 target
- Pico W target

## Hardware evidence

<img width="1280" height="960" alt="Tested on a physical Waveshare RP2350B-Plus-W" src="https://github.com/user-attachments/assets/1be932d7-580a-4836-8921-6478279d954e" />
