### PR TITLE
fix(audio): re-arm mic streaming when the controller reconnects

### DIFF
--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -8,6 +8,7 @@
 #include <queue>
 #include <unordered_map>
 #include <vector>
+#include "audio.h"
 #include "btstack_event.h"
 #include "btstack_tlv.h"
 #include "gap.h"
@@ -753,6 +754,13 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
                         .LedBlue = 0x00,
                     };
                     update_state(state);
+
+                    // Re-arm controller mic streaming for the new link. The 0x32
+                    // mic-status packet is otherwise only sent when the host opens
+                    // or closes the USB mic interface, so a controller that
+                    // reconnects while the host still holds that interface open
+                    // never gets told to stream and the mic stays silent.
+                    update_mic_status();
 
                     const auto mtu = l2cap_get_remote_mtu_for_local_cid(hid_interrupt_cid);
                     printf("[L2CAP] Remote Interrupt MTU: %d\n", mtu);


### PR DESCRIPTION
## Problem

`update_mic_status()` sends the `0x32` packet that tells the controller to start streaming its mic. It is only ever reached from `set_mic_active()`, which in turn only runs from `tud_audio_set_itf_cb` — that is, when the *host* opens or closes the USB mic interface.

If the controller drops and reconnects while the host still holds that interface open, the new link is never told to stream. The mic goes silent until the host closes and reopens the interface, which in practice means the user re-selecting the recording device.

## Reproduce

1. Select `DualSense Wireless Controller` as the recording device and confirm the mic works.
2. Hold PS to power the controller off.
3. Turn it back on and let it reconnect.

Everything else comes back — buttons, rumble, speaker — but the mic captures nothing.

## Change

Call `update_mic_status()` from the HID connect path, alongside the existing `update_state()`.

No new state is tracked. `update_mic_status()` already derives the enable bit itself:

```c
pkt[4] = (mic_active && get_config().mic_select != 3) ? 0b00000011 : 0b00000010;
```

so a host that has not opened the mic interface still correctly receives the disable variant.

## Testing

Pico 2 W, DualSense, Pico SDK 2.3.0, standard build.

- power-cycle the controller with a headset attached → mic resumes ✔
- power-cycle with no headset → mic resumes on the built-in array ✔
- fresh connect with the host opening the interface afterwards → unchanged ✔

This may well be the same root cause as #167 ("Mic only starts after selecting DualSense as Windows output once") — same symptom reached by a different trigger.

Refs #167
