### PR TITLE
feat(audio): switch to the headset mic when one is plugged in

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -44,6 +44,7 @@ static WDL_Resampler resampler;
 extern uint8_t reportSeqCounter;
 extern uint8_t packetCounter;
 static bool plug_headset = false;
+static bool plug_mic = false;   // controller reports a mic on the 3.5 mm jack
 static bool mic_active = false; // host has opened the mic IN interface (alt != 0)
 alignas(8) static uint32_t audio_core1_stack[7000];
 queue_t audio_fifo; // raw pcm data
@@ -75,6 +76,26 @@ struct haptics_element {
 
 void set_headset(bool state) {
     plug_headset = state;
+}
+
+// PluggedMic (input report 53.1). Tracked separately from PluggedHeadphones
+// because a 3-pole plug asserts the headphone bit with no mic behind it.
+void set_plug_mic(bool state) {
+    plug_mic = state;
+}
+
+// The controller's own Auto mode keeps the builtin mic even with a headset mic
+// plugged in, so resolve auto here the way the speaker path already does with
+// plug_headset.
+//
+// Both branches must return a concrete value: once External Only has been sent,
+// the controller latches it, so unplugging the headset has to actively push it
+// back to Internal Only. Returning 0 ("leave it in Auto") on unplug means no
+// report is sent at all and the mic goes silent with no external mic present.
+uint8_t effective_mic_select() {
+    const uint8_t configured = get_config().mic_select;
+    if (configured != 0) return configured;
+    return plug_mic ? 2 : 1; // 2 = External Only, 1 = Internal Only
 }
 
 // Called from tud_audio_set_itf_cb when the host opens/closes the mic IN

--- a/src/audio.h
+++ b/src/audio.h
@@ -11,6 +11,11 @@ void audio_init();
 void audio_loop();
 void core1_entry();
 void set_headset(bool state);
+void set_plug_mic(bool state);
+// Resolves config.mic_select into the MicSelect to send to the controller: the
+// configured value when the user set one, otherwise External/Internal Only
+// depending on whether a jack mic is present. Always concrete, never Auto.
+uint8_t effective_mic_select();
 void set_mic_active(bool active);
 bool audio_mic_active();
 void mic_add_queue(uint8_t *data, uint16_t len);

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -8,6 +8,7 @@
 #include <queue>
 #include <unordered_map>
 #include <vector>
+#include "audio.h"
 #include "btstack_event.h"
 #include "btstack_tlv.h"
 #include "gap.h"
@@ -742,7 +743,7 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
                     SetStateData state = {
                         .AllowAudioControl = 1,
                         .AllowLedColor = 1,
-                        .MicSelect = get_config().mic_select,
+                        .MicSelect = effective_mic_select(),
                         .AllowLightBrightnessChange = 1,
                         .AllowColorLightFadeAnimation = 1,
                         .LightFadeAnimation = LightFadeAnimation::FadeOut,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstring>
 
+#include "audio.h"
 #include "bt.h"
 #include "status_gpio.h"
 #include "utils.h"
@@ -198,7 +199,7 @@ void set_config(const uint8_t *new_config, const uint16_t len) {
         state.SpeakerCompPreGain = config.body.speaker_gain;
     }
     state.AllowAudioControl = 1;
-    state.MicSelect = config.body.mic_select;
+    state.MicSelect = effective_mic_select();
     update_state(state);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,6 +105,20 @@ void __not_in_flash_func(on_bt_data)(CHANNEL_TYPE channel, uint8_t *data, uint16
         if ((data[56] & 1) != (interrupt_in_data[53] & 1)) {
             set_headset(data[56] & 1);
         }
+        // PluggedMic (53.1) drives mic auto. The controller will not move off the
+        // builtin mic by itself, so re-push MicSelect whenever the jack mic
+        // appears or goes away; a plug event is the only moment it can change.
+        if (((data[56] >> 1) & 1) != ((interrupt_in_data[53] >> 1) & 1)) {
+            set_plug_mic((data[56] >> 1) & 1);
+#if ENABLE_VERBOSE
+            printf("[Audio] PluggedHeadphones=%u PluggedMic=%u PluggedExternalMic=%u\n",
+                   data[56] & 1, (data[56] >> 1) & 1, data[57] & 1);
+#endif
+            SetStateData state{};
+            state.AllowAudioControl = 1;
+            state.MicSelect = effective_mic_select();
+            update_state(state);
+        }
         if (((data[56] >> 2) & 1) != ((interrupt_in_data[53] >> 2) & 1)) {
             const SetStateData state{
                 .AllowMuteLight = 1,
@@ -257,9 +271,13 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
                     state.AllowAudioControl2 = 1;
                     state.SpeakerCompPreGain = config.speaker_gain;
                 }
-                if (config.mic_select != 0) {
-                    state.AllowAudioControl = 1;
-                    state.MicSelect = config.mic_select;
+                // Only correct MicSelect when the host's own report already carries
+                // an AudioControl section. Newly setting AllowAudioControl here
+                // would also apply the host's unset OutputPathSelect / echo /
+                // noise-cancel fields; the value pushed on the last plug event or
+                // at connect stays latched on the controller regardless.
+                if (state.AllowAudioControl) {
+                    state.MicSelect = effective_mic_select();
                 }
                 if (config.lock_volume) {
                     state.AllowHeadphoneVolume = 0;


### PR DESCRIPTION
## Problem

With `mic_select = 0` (auto, the default) the dongle keeps capturing the controller's built-in mic array even when a headset with a mic is plugged into the 3.5 mm jack.

In auto, the SetState passthrough never asserts the field at all:

```c
if (config.mic_select != 0) {
    state.AllowAudioControl = 1;
    state.MicSelect = config.mic_select;
}
```

So auto delegates entirely to the controller's own Auto mode, which stays on the built-in mic. The speaker path already resolves auto in firmware using `plug_headset` (`audio.cpp`), so mic auto was the only one not doing it:

```c
pkt[140] = ((
    cfg.speaker_select == 2 ||                    // lock headphone
    (cfg.speaker_select == 0 && plug_headset)     // auto
    ) ? 0x16 : 0x13) | 1 << 6 | 1 << 7;
```

`PluggedMic` (input report `53.1`) was already arriving and being ignored — only `53.0 PluggedHeadphones` and `53.2 MicMuted` were read from that byte.

## Change

Track `PluggedMic` and resolve auto in one place:

```c
uint8_t effective_mic_select() {
    const uint8_t configured = get_config().mic_select;
    if (configured != 0) return configured;
    return plug_mic ? 2 : 1; // 2 = External Only, 1 = Internal Only
}
```

Both branches return a concrete value deliberately. The controller latches `MicSelect`, so unplugging has to push it back actively — returning "leave it in Auto" means no report goes out at all and the mic goes silent with no external mic present. That was a real bug in an earlier revision of this patch.

`MicSelect` is pushed on every `PluggedMic` edge and at controller connect.

In the host SetState passthrough the field is only corrected when the host's report already carries an AudioControl section:

```c
if (state.AllowAudioControl) {
    state.MicSelect = effective_mic_select();
}
```

Newly asserting `AllowAudioControl` there would also apply the host's unset `OutputPathSelect` / `EchoCancelEnable` / `NoiseCancelEnable` fields, which could reroute audio output for hosts that never touched that section. This is narrower than the code it replaces.

### Behaviour change

In auto with no jack mic, the firmware now sends `Internal Only` rather than leaving the controller in `Auto`. Audibly identical, but deterministic.

Explicit `mic_select` (1 / 2 / 3) resolves exactly as before.

## Testing

Pico 2 W, DualSense, Pico SDK 2.3.0, standard build. `mic_select` set via `tools/config_tool.py` — the field is not exposed in the hosted web config.

- auto, no headset → controller mic ✔
- auto, plug headset → headset boom mic ✔
- auto, unplug → back to the controller mic, no reconnect needed ✔
- auto, re-plug → headset mic ✔
- controller power-cycled with headset attached → resumes on the headset boom ✔
- game audio output unchanged (controller speaker / headphone routing) ✔
- `mic_select = 2` fixed, headset attached → headset mic ✔

Which capsule was live was confirmed by covering the controller's mic array and watching the input level, not by the endpoint name.

One note on the power-cycle case: verifying it required #242, since without that fix the mic stays silent after any controller reconnect regardless of `mic_select`. The two are independent — this PR does not depend on it — but #242 is what makes this path observable.

Refs #56
