### PR TITLE
feat(esp32s31): ESP32-S31 target via a platform abstraction layer

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -49,10 +49,20 @@ on:
         required: false
         type: boolean
         default: false
+      esp32s31:
+        description: Also build the ESP32-S31 merged flash image
+        required: false
+        type: boolean
+        default: false
 
 env:
   PICO_SDK_REF: 2.3.0
   TINYUSB_REF: 2d56dc533e45e4e91b15e93fdab5e22e964f328d
+  # esp32s31 is a preview target: it exists only on ESP-IDF master, which has no
+  # tagged release and no versioned container image. Pinned by commit for the same
+  # reason PICO_SDK_REF and TINYUSB_REF are -- floating on espressif/idf:latest
+  # broke this job when master changed under it.
+  IDF_REF: 08e0d30a74ad0bfd5a34933142b80f45619ee410
   PICO_SDK_PATH: ${{ github.workspace }}/pico-sdk
   ARM_TOOLCHAIN_VERSION: 15.2.rel1
   ARM_TOOLCHAIN_URL: https://gitlab.arm.com/api/v4/projects/tooling%2Fgnu-toolchains-for-arm/packages/generic/gnu-toolchain/15.2.rel1/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi.tar.xz
@@ -289,6 +299,95 @@ jobs:
         with:
           name: ${{ matrix.artifact }}${{ steps.firmware-meta.outputs.asset_suffix }}
           path: artifacts/${{ matrix.artifact }}${{ steps.firmware-meta.outputs.asset_suffix }}.uf2
+          archive: false
+          if-no-files-found: error
+
+  esp32s31:
+    name: Build ESP32-S31 firmware
+    if: inputs.esp32s31
+    runs-on: ubuntu-latest
+    env:
+      IDF_PATH: ${{ github.workspace }}/esp-idf
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.repo == '' && github.repository || inputs.repo }}
+          ref: ${{ inputs.ref }}
+          submodules: recursive
+
+      - name: Resolve firmware metadata
+        id: firmware-meta
+        shell: bash
+        env:
+          IN_VER: ${{ inputs.version }}
+          IN_ASSET_SUFFIX: ${{ inputs.asset_suffix }}
+          IN_UPLOAD_TAG: ${{ inputs.upload_tag }}
+        run: |
+          v="$IN_VER"
+          if printf '%s' "$v" | grep -qE '^[0-9a-f]{40}$'; then
+            v="${v:0:7}"
+          fi
+          echo "FW_VER=$v" >> "$GITHUB_ENV"
+
+          asset_suffix="$IN_ASSET_SUFFIX"
+          if [ -z "$asset_suffix" ] && [ -z "$IN_UPLOAD_TAG" ]; then
+            asset_suffix="-$(git rev-parse --short=7 HEAD)"
+          fi
+          echo "asset_suffix=$asset_suffix" >> "$GITHUB_OUTPUT"
+
+      - name: Cache ESP-IDF and tools
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/esp-idf
+            ~/.espressif
+          key: ${{ runner.os }}-idf-${{ env.IDF_REF }}-esp32s31
+
+      - name: Install ESP-IDF at the pinned ref
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git wget flex bison gperf python3 python3-pip \
+            python3-venv cmake ninja-build ccache libffi-dev libssl-dev dfu-util
+
+          # Fetch just the pinned commit rather than the full history.
+          if [ ! -d "$IDF_PATH/.git" ]; then
+            git init "$IDF_PATH"
+            git -C "$IDF_PATH" remote add origin https://github.com/espressif/esp-idf.git
+            git -C "$IDF_PATH" fetch --depth 1 origin "$IDF_REF"
+            git -C "$IDF_PATH" checkout --detach FETCH_HEAD
+            git -C "$IDF_PATH" submodule update --init --depth 1 --recursive
+          fi
+          "$IDF_PATH/install.sh" esp32s31
+
+      - name: Build ESP32-S31 firmware
+        shell: bash
+        env:
+          ASSET_SUFFIX: ${{ steps.firmware-meta.outputs.asset_suffix }}
+        run: |
+          . "$IDF_PATH/export.sh"
+
+          VERSION_ARG=()
+          [ -n "${FW_VER:-}" ] && VERSION_ARG=(-DVERSION="$FW_VER")
+
+          # --preview is required: esp32s31 is not a released target.
+          # The target itself comes from ports/esp32s31/sdkconfig.defaults.
+          idf.py --preview -C ports/esp32s31 "${VERSION_ARG[@]}" build
+
+          # Single image at offset 0, so flashing needs no per-file offsets.
+          idf.py --preview -C ports/esp32s31 merge-bin \
+            -o ds5-bridge-esp32s31-merged.bin
+
+          mkdir -p artifacts
+          cp ports/esp32s31/build/ds5-bridge-esp32s31-merged.bin \
+             "artifacts/ds5-bridge-esp32s31-merged${ASSET_SUFFIX}.bin"
+
+      - name: Upload ESP32-S31 artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ds5-bridge-esp32s31-merged${{ steps.firmware-meta.outputs.asset_suffix }}
+          path: artifacts/ds5-bridge-esp32s31-merged${{ steps.firmware-meta.outputs.asset_suffix }}.bin
           archive: false
           if-no-files-found: error
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,4 @@ jobs:
       picow: true
       waveshare: true
       no_batt_led_check: true
+      esp32s31: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ example
 .DS_Store
 .cache
 /tools/__pycache__
+build-baseline/
+build-orig/
+sdkconfig
+sdkconfig.old
+ports/esp32s31/build/
+ports/esp32s31/managed_components/
+build-pico/

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "lib/opus"]
 	path = lib/opus
 	url = https://github.com/xiph/opus
+[submodule "lib/btstack"]
+	path = lib/btstack
+	url = https://github.com/bluekitchen/btstack.git
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,16 @@ add_executable(ds5-bridge
         src/cmd.cpp
         src/ram_mem.c
         src/fake_ds5.h
+        # Platform abstraction layer; the ESP32-S31 target selects the
+        # esp32s31 backend instead (see ports/esp32s31/CMakeLists.txt).
+        src/port/pico/port_pico.cpp
 )
+
+target_include_directories(ds5-bridge PRIVATE src)
+
+# Portable spelling of the firmware version string; the ESP32-S31 build defines
+# this directly since it has no pico-sdk program metadata.
+target_compile_definitions(ds5-bridge PRIVATE DS5_FIRMWARE_VERSION=PICO_PROGRAM_VERSION_STRING)
 
 if (ENABLE_DEBUG)
         target_sources(ds5-bridge PRIVATE src/debug.cpp)

--- a/ports/esp32s31/CMakeLists.txt
+++ b/ports/esp32s31/CMakeLists.txt
@@ -1,0 +1,88 @@
+# ESP-IDF project for the ESP32-S31-Function-CoreBoard-1 target.
+#
+# Build with:
+#   idf.py -C ports/esp32s31 set-target esp32s31
+#   idf.py -C ports/esp32s31 build
+#
+# The Pico2W / Waveshare builds continue to use the top-level CMakeLists.txt and
+# are unaffected by anything here.
+
+cmake_minimum_required(VERSION 3.16)
+
+set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/components")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# TinyUSB includes "tusb_config.h" from its own sources, and BTstack includes
+# "btstack_config.h" from its own -- both expect the application's copy to be
+# globally reachable, which is how the pico-sdk build provides them. Put the
+# firmware's src/ on every component's include path to match.
+idf_build_set_property(COMPILE_OPTIONS "-I${CMAKE_CURRENT_LIST_DIR}/../../src" APPEND)
+
+# CFG_TUSB_MCU/CFG_TUSB_OS must agree between the application and the TinyUSB
+# library or their shared types diverge (tu_fifo_t carries an osal_mutex_t).
+# Setting them per-component let the library fall through to tusb_config.h's
+# default while the app compiled with something else.
+#
+# OPT_OS_NONE, emphatically NOT OPT_OS_FREERTOS: tud_task() is
+# tud_task_ext(UINT32_MAX, false), and under the FreeRTOS OSAL that timeout
+# blocks the caller until a USB event arrives. This firmware calls it from a
+# superloop that must also service BTstack and feed the watchdog, so FreeRTOS
+# osal deadlocks on the first idle iteration.
+#
+# Safe here because the USB ISR and tud_task() are both on core 0, and
+# osal_none guards its FIFO by masking interrupts; nothing on core 1 touches
+# TinyUSB.
+idf_build_set_property(COMPILE_OPTIONS "-DCFG_TUSB_MCU=OPT_MCU_ESP32S31" APPEND)
+idf_build_set_property(COMPILE_OPTIONS "-DCFG_TUSB_OS=OPT_OS_NONE" APPEND)
+
+# Enumerate as a HIGH-speed device, matching the real DualSense. The S31's only
+# PHY is high-speed, so the PHY the core selects and the one the SoC bonds out
+# agree. bInterval is an exponent at high speed; ep_interval() in
+# src/usb_descriptors.cpp encodes it for whichever speed is built.
+idf_build_set_property(COMPILE_OPTIONS "-DBOARD_TUD_MAX_SPEED=OPT_MODE_HIGH_SPEED" APPEND)
+
+# dwc2 fixes for this part, applied to dcd_dwc2.c at configure time:
+#
+#   - clear_stall sets EPCTL_SD0PID_SEVNFRM unconditionally; on an iso endpoint
+#     that is SetEvenFrame, retargeting an already-armed transfer.
+#   - The armed (micro)frame is one interval away, not the next one -- the two
+#     coincide only at interval 1, so this is invisible at full speed.
+#   - GINTSTS_PXFR_INCOMPISOOUT was declared and never handled.
+#   - The USB interrupt is allocated at LEVEL3, not LOWMED, for its 1 ms
+#     deadline.
+#
+# managed_components/ is generated and git-ignored, so these live here as a
+# patch rather than an edit a re-fetch would silently discard. Drop once
+# upstream carries them.
+project(ds5-bridge-esp32s31)
+
+set(TINYUSB_SRC "${CMAKE_CURRENT_LIST_DIR}/managed_components/espressif__tinyusb")
+set(DWC2_PATCH "${CMAKE_CURRENT_LIST_DIR}/patches/tinyusb-dwc2-esp32s31.patch")
+# MUST come after project(): the component manager materialises
+# managed_components/ as part of project(), so a guard placed before it tests a
+# directory that does not exist yet on a fresh tree, silently skips the patch and
+# ships a build with a broken isochronous OUT path. Compiling cleanly hides it.
+if(EXISTS "${TINYUSB_SRC}/src/portable/synopsys/dwc2/dcd_dwc2.c")
+    # --dry-run first so an already-patched tree is a no-op rather than an error;
+    # the component manager re-materialises this directory without warning.
+    execute_process(
+        COMMAND patch -p1 --forward --dry-run --input "${DWC2_PATCH}"
+        WORKING_DIRECTORY "${TINYUSB_SRC}"
+        RESULT_VARIABLE dwc2_patch_needed
+        OUTPUT_QUIET ERROR_QUIET)
+    if(dwc2_patch_needed EQUAL 0)
+        message(STATUS "Applying TinyUSB dwc2 isochronous-OUT patch")
+        execute_process(
+            COMMAND patch -p1 --forward --input "${DWC2_PATCH}"
+            WORKING_DIRECTORY "${TINYUSB_SRC}"
+            RESULT_VARIABLE dwc2_patch_result)
+        if(NOT dwc2_patch_result EQUAL 0)
+            message(FATAL_ERROR "TinyUSB dwc2 patch failed to apply")
+        endif()
+    endif()
+else()
+    message(FATAL_ERROR
+        "TinyUSB sources not found at ${TINYUSB_SRC}; the dwc2 patch cannot be "
+        "applied. Failing loudly rather than shipping an unpatched build.")
+endif()

--- a/ports/esp32s31/README.md
+++ b/ports/esp32s31/README.md
@@ -1,0 +1,497 @@
+# ESP32-S31-Function-CoreBoard-1 port
+
+The firmware runs on this target. Verified on hardware: pairing, reconnect after
+both a PS-hold power-cycle and a dongle replug, USB enumeration of the emulated
+controller, speaker and microphone audio under sustained load, and the lightbar
+handover after a power-cycle. Read the cabling note below before wiring anything
+up.
+
+The Pico2W / Waveshare RP2350B builds are unaffected; they still build from the
+top-level `CMakeLists.txt` and were verified unchanged by this work.
+
+## USB cabling: use a data-only A-to-A cable
+
+The dongle must appear to the PC as a USB **device**. That works on this board,
+but the cable matters.
+
+The ESP32-S31 has one OTG peripheral with only a UTMI (high-speed) PHY —
+`soc_caps.h`: `SOC_USB_UTMI_PHY_NUM 1`, `SOC_USB_FSLS_PHY_NUM 0` — and on this
+board `USB_DP`/`USB_DM` go to the Type-A receptacle (Port 4). Neither Type-C
+port reaches OTG: Port 5 is USB Serial/JTAG, Port 6 the USB-to-UART bridge.
+
+**A Type-A receptacle does not force host role.** For the UTMI PHY, device vs
+host is a software choice — `usb_phy.c`'s set-mode path simply disconnects the
+D+/D- pulldowns for device mode and returns, with no ID pin or VBUS-valid signal
+involved. D+, D- and GND are symmetric, so the connector shell is irrelevant to
+signalling. `board_init()` already selects `USB_OTG_MODE_DEVICE`.
+
+The one genuine conflict is **VBUS**: this board sources 5 V on that port
+through a TPS2051C, and so does the PC. Tying two 5 V supplies together is out
+of spec and can back-feed the host port.
+
+So:
+
+1. Use an A-to-A cable with **VBUS isolated** — D+, D- and GND pass through.
+2. Power the board from either Type-C port.
+
+**VBUS on that port is always live — confirmed from the schematic.** U5
+(TPS2051CDBVR) has its active-high `EN` (pin 4) on the `VBUS_EN` net, which is
+pulled up to `VCC_5V` through R25 (10k, populated); the pull-down R29 (10k) is
+marked NC and not fitted. `VBUS_EN` reaches no GPIO, so no firmware change can
+switch it off. Verified on hardware: a USB mouse plugged into the Type-A port
+powers up.
+
+Isolating VBUS in the cable is therefore mandatory, not conditional. (TP1 is a
+test point directly on `VBUS_OUT` if you want to measure it.)
+
+To isolate, tape over pin 1 (the VBUS contact) of one Type-A plug rather than
+cutting — reversible and keeps the cable usable. Note that off-the-shelf "USB
+data blockers" do the opposite of what is wanted here: they pass power and block
+data.
+
+Note the asymmetry: the TPS2051C's reverse blocking protects the *board* from
+host VBUS. It does nothing to stop the board driving 5 V *out* into the host
+port, which is the direction that matters here.
+
+### Single-PC-port option (Y-cable)
+
+If two cables is unacceptable, one custom cable off a single PC port works,
+because J2 exposes 5 V (pins 39/40, GND on 37/38) and the user guide lists
+"5V and G (GND) pin headers" as a supported power input:
+
+- D+, D-, GND from the PC plug -> the board's Type-A port (omit its VBUS branch)
+- VBUS, GND from the same PC plug -> J2 5 V and G
+
+That powers the board and carries data over the real high-speed peripheral.
+Watch the current budget (USB 2.0 gives 500 mA; this board has an Ethernet PHY
+and PSRAM), and do not leave a Type-C plugged in at the same time -- that is two
+sources into one rail. Bonus: with VBUS present at the header you can divide it
+down to a spare GPIO and pass it as `bvalid_io_num`, which fixes the
+attach-detection caveat above.
+
+Bit-banging USB over GPIO is not a workable alternative. Low speed -- the only
+speed realistically bit-bangable -- has no isochronous endpoints at all (control
+and interrupt only, 8-byte packets), so the audio class is impossible and the
+64-byte DS5 reports do not fit. Full speed needs NRZI, bit stuffing, CRC and
+turnaround responses at ~20 CPU cycles per bit; the RP2040 only manages it via
+PIO, and the S31 has no equivalent (PARLIO is unidirectional parallel-with-clock,
+RMT is pulse gen/capture, BitScrambler is a data transform). It would also mean
+discarding a working USB 2.0 high-speed peripheral.
+
+### Why not a Type-C port
+
+Neither Type-C port can carry the controller data, so a single-*connector* setup
+is not available. They reach different peripherals: Port 5 is the S31's USB
+Serial/JTAG block, which is fixed-function (CDC-ACM + JTAG, descriptors in
+hardware — the driver exposes no descriptor API), and Port 6 goes to a separate
+USB-to-UART bridge chip that never touches the S31's USB pins. Only the Type-A
+port reaches USB OTG, the one peripheral TinyUSB's device stack can drive.
+Putting OTG on a Type-C would mean rewiring `USB_DP`/`USB_DM` to a new
+connector, plus 5.1k Rd pulldowns on CC1/CC2 to present as a device port — a
+custom board, not a mod to this one.
+
+You cannot power the board *through* the Type-A port instead. Its 5 V comes
+from the board rail via the TPS2051C, so it is an output; TI lists reverse
+current blocking as a feature of that part, so host VBUS cannot flow back into
+the rail. Leaving VBUS connected therefore buys nothing and still lets the board
+push 5 V into the host port. Expect two cables: Type-C for power (wanted anyway
+for flashing and the serial monitor) and the data-only A-to-A to the PC.
+
+The SoC never drives VBUS itself: `otg_io_conf` is left null, so `drvvbus` is
+never routed out — the self-powered-device shape IDF documents as
+`USB_PHY_SELF_POWERED_DEVICE()`. The 5 V on the receptacle comes from the
+TPS2051C alone, and with VBUS cut it simply goes nowhere.
+
+Known limitation: with no VBUS sense the device attaches whenever it is powered
+rather than when the host appears. To do it properly, wire the connector's VBUS
+through a divider to a spare GPIO and pass it as `bvalid_io_num`.
+
+The TPS2051C's enable is **not** GPIO-controlled — see above; it is strapped
+high by R25 with the R29 pull-down unpopulated. Firmware cannot drop VBUS. The
+hardware alternative to taping the cable is to remove R25 and populate R29,
+which straps `EN` low; taping is easier and reversible, so it is the
+recommendation.
+
+## Why the ESP32-S31 at all
+
+The DualSense speaks Bluetooth **Classic** (BR/EDR) HID, which rules out most of
+the line: the S3, C3, C6 and H2 are BLE-only, and the original ESP32 has BR/EDR
+but no USB device peripheral. The S31 is the first Espressif part with both.
+
+Confirmed in ESP-IDF master rather than assumed:
+`components/soc/esp32s31/include/soc/soc_caps.h` defines
+`SOC_BT_CLASSIC_SUPPORTED (1)`, and the controller ships a prebuilt
+`libbredr_app.a` under `components/bt/controller/lib_esp32s31/`.
+
+## Build
+
+```sh
+idf.py --preview -C ports/esp32s31 set-target esp32s31
+idf.py --preview -C ports/esp32s31 build
+```
+
+`--preview` is required: esp32s31 is still a preview target in ESP-IDF.
+
+Needs ESP-IDF **master** (verified against v6.2.0, commit 08e0d30a) — esp32s31
+is not in a tagged release. Note that `install.sh` pulls openocd, which needs a
+system `libusb-1.0`; openocd is only for JTAG debugging and the build works
+without it.
+
+## BOOT button
+
+GPIO61, not GPIO0 -- see `src/port/esp32s31/board_esp32s31.h`. The gesture set is
+shared with the Pico build and unchanged, except that there is no third gesture:
+
+| Gesture | Action |
+| --- | --- |
+| 1 click | pair / switch controller (fresh inquiry) |
+| 2 clicks | reboot |
+| 3 clicks | nothing (Pico: reboot to BOOTSEL) |
+| hold ~1.5 s | clear all pairings, six LED flashes to confirm |
+
+Triple click is dropped rather than remapped, because the RP2350 gesture is
+buying something this board does not need. On the Pico, BOOTSEL has to be held
+*during* power-up, so a firmware call into the bootrom saves an unplug/replug. On
+the ESP32-S31 the host tool straps the chip into download boot by itself over
+DTR/RTS, so nothing is saved. It deliberately does not fall through to a reboot
+either: a mis-counted click would then drop the controller link.
+
+Nor could it be implemented honestly here. Download boot exists in S31 silicon --
+there is an `EFUSE_DIS_FORCE_DOWNLOAD` bit to switch it off, which would be
+pointless otherwise -- but the register that forces it from software is not
+exposed for this target anywhere in ESP-IDF master. The only IDF code that does
+this (`esp_usb_cdc_rom_console`) writes
+`RTC_CNTL_OPTION1_REG.FORCE_DOWNLOAD_BOOT`, and the S31 has no `rtc_cntl_reg.h`
+at all, nor an `LP_AON` equivalent. Guessing an address on preview silicon is how
+boards get wedged, so `port::has_bootloader_reboot()` returns false here. If a
+later IDF exposes the register, implement `reboot_to_bootloader()` and flip that
+one function to true to get parity back.
+
+## Status
+
+Builds clean: `ds5-bridge-esp32s31.bin`, 962 KB, with the BR/EDR controller and
+BTstack Classic linked in.
+
+Working:
+
+- `src/port/` platform abstraction, Pico backend and ESP32-S31 backend. The Pico
+  firmware grows 424 bytes of text against unmodified master — the abstraction
+  is effectively free.
+- Config storage on `esp_partition` with a RAM shadow (IDF cannot erase a
+  mapped partition, so the RP2350's XIP-pointer trick does not carry over),
+  `esp_timer` one-shots, GPIO61 boot button, RMT-driven WS2812 status LED, task
+  watchdog, USB PHY bring-up, core-1 audio worker as a pinned static task.
+- BTstack built from `lib/btstack` (pinned to the same commit the Pico SDK
+  uses) with the on-die controller in BR/EDR-only, controller-only mode.
+  Verified in the generated sdkconfig: `CONFIG_BT_CTRL_BREDR_ENABLE=y`.
+- HCI transport over VHCI (`src/port/esp32s31/bt_transport_esp32s31.cpp`),
+  driving the pollable embedded run loop from the superloop. See below.
+- This target enumerates at HIGH speed, matching the real DualSense (confirmed
+  from its descriptors on hardware) rather than the RP2350, which has no
+  high-speed PHY. The S31's only PHY is high-speed, so this is also the
+  path of least resistance -- see "High speed" below for what it required.
+  The descriptors are the Pico build's except for `bInterval`, which
+  `ep_interval()` in `src/usb_descriptors.cpp` re-encodes per speed: at high
+  speed it is an exponent, so the 1 ms audio and HID endpoints carry 4 rather
+  than 1. Everything else is byte-for-byte identical and worth re-checking if
+  either side is touched:
+
+      riscv32-esp-elf-objdump -s --start-address=<sym> ...   # ESP32
+      arm-none-eabi-objdump   -s --start-address=<sym> ...   # Pico
+- libopus and the WDL resampler as IDF components, reusing the same submodules
+  the Pico build compiles.
+
+### Gotchas already worked around
+
+Each of these silently does the wrong thing rather than failing loudly:
+
+- BTstack's `port/esp32` `btstack_config.h` only defines `ENABLE_CLASSIC` under
+  `CONFIG_IDF_TARGET_ESP32`, and its component gates `src/classic` the same way
+  — both written when the original ESP32 was the only BR/EDR part. Left alone,
+  BR/EDR quietly vanishes on S31.
+- `btstack_port_esp32.c` sizes its HCI ring buffer with Bluedroid's `HCI_HOST_*`
+  macros, which no longer exist in IDF 6.2 under `CONFIG_BT_CONTROLLER_ONLY`.
+- `espressif/esp_tinyusb` ships a `tusb_config.h` on a public include path that
+  shadows the firmware's and disables the device stack, and defines descriptor
+  callbacks that clash with `usb_descriptors.cpp`. Use raw `espressif/tinyusb`.
+- `CONFIG_BT_CLASSIC_ENABLED` is a Bluedroid **host** symbol and does nothing
+  here; `CONFIG_BTDM_CTRL_MODE_BR_EDR_ONLY` is what sets `BT_CTRL_BREDR_ENABLE`.
+- TinyUSB calls back into `main` for descriptors with nothing pointing that way
+  in the dependency graph, so `main` needs `WHOLE_ARCHIVE`.
+- **The DualSense keeps its own lightbar in wireless mode** until the host
+  pulses `ResetLights` (`src/utils.h` bit 1.3), and Steam never sends that bit --
+  verified, `reset=0` on every host output report. A fresh pair releases the LEDs
+  anyway; a PS-hold power-cycle does not, so the lightbar sticks on the
+  controller's connect blue and ignores every colour the host asks for.
+  `bt_task()` pulses the bit alone 3s after the HID interrupt channel opens, then
+  repaints the host's last colour 120ms later. Two reports, because the
+  controller takes the handover and ignores a colour carried in the same one.
+
+### High speed
+
+This target enumerates at high speed. So does the real DualSense (confirmed
+from its descriptors on hardware), and the S31's only PHY is high-speed, so
+this is both the faithful choice and the natural one -- the RP2350 is
+full-speed only because it has no alternative.
+
+Four things had to be right together. Each fails quietly on its own, which is
+why partial attempts looked like dead ends:
+
+- **`bInterval` encoding.** A frame count at full speed, an exponent at high
+  speed, so a literal 1 asks for 125 us rather than 1 ms. The audio OUT
+  endpoint (`wMaxPacketSize` 392 -- one 1 ms frame of 48 kHz 4-channel 16-bit)
+  then described a device that cannot exist: the host took a single
+  isochronous OUT packet and abandoned the stream. `ep_interval()` in
+  `src/usb_descriptors.cpp` re-encodes per speed.
+
+- **Isochronous handling in dwc2.** `EPCTL_SD0PID_SEVNFRM` is SetEvenFrame on
+  an isochronous endpoint, not a data toggle; and the target (micro)frame is
+  one *interval* away, not the next one. Those coincide only at interval 1, so
+  both defects are invisible at full speed and fatal at high speed, where
+  `bInterval` 4 means 8 microframes. See `patches/tinyusb-dwc2-esp32s31.patch`.
+
+- **USB interrupt priority and placement.** `esp_intr_alloc` was called with
+  `ESP_INTR_FLAG_LOWMED` -- the lowest free level -- for an ISR with a 1 ms
+  deadline, and `dcd_int_handler` sat in flash while the rest of the hot path
+  had been moved to RAM. Now LEVEL3, and in `main/ds5_hot_iram.lf`.
+
+- **Bluetooth controller core.** `esp_intr_alloc` registers the USB interrupt
+  on whichever core calls it, which is the main task on core 0. With the BT
+  controller also on core 0, its interrupt-disabling critical sections stalled
+  the isochronous endpoint for milliseconds at a time -- about 4% of packets
+  lost, heard as static. It leaves the main loop untouched, so loop-level
+  instrumentation cannot see it. `CONFIG_BT_CTRL_PINNED_TO_CORE=1`.
+
+Full speed is possible here but is not what ships, and is recorded because the
+obvious way to ask for it bricks the bus. `DCFG.DevSpd = DCFG_DSPD_FS_HSPHY`
+signals full speed over the high-speed PHY; what does not work is asking
+TinyUSB. `dwc2_core_is_highspeed_phy()` decides from `GHWCFG2.fs_phy_type`, an
+RTL parameter describing what the core supports rather than what the SoC bonds
+out: the S31 reports 2 ("FS pins shared with UTMI+ pins") while `soc_caps.h`
+says `SOC_USB_FSLS_PHY_NUM 0` and `gpio_sig_map.h` routes no USB OTG signals
+at all. So `BOARD_TUD_MAX_SPEED=OPT_MODE_FULL_SPEED` runs `phy_fs_init()`,
+sets `GUSBCFG.PHYSEL=1`, points the core at a transceiver that does not exist,
+and `reset_core()` latches it -- a silent bus, nothing enumerated. Writing
+`DCFG.DevSpd` afterwards cannot undo it. Espressif's own `esp_tinyusb`
+hardcodes high speed for this part and states the port "is always HS".
+
+`usb_log_speed()` prints `DCFG.DevSpd` and `DSTS.enum_speed` at boot. DevSpd is
+what was requested; DSTS is what the link negotiated, and only the second is
+evidence.
+
+### Threading model
+
+Worth understanding before changing anything here.
+
+BTstack's own `port/esp32` hardwires `btstack_run_loop_freertos`, whose
+`execute()` never returns -- it owns the calling task. `main.cpp` is a superloop
+that must keep servicing TinyUSB, so it cannot hand its task over. Running
+BTstack on a separate task instead would move every `bt.cpp` callback off the
+USB thread, and the shared code is not written for that: `bt_write()` uses a
+single static `send_element` and the report sequence counters are non-atomic,
+safe only because the Pico ran them strictly sequentially on core 0.
+
+So this port mirrors the Pico's cooperative arrangement instead: the pollable
+`btstack_run_loop_embedded`, pumped from `port::bt_transport_poll()` exactly
+where the Pico build called `cyw43_arch_poll()`. Every BTstack callback runs on
+the main task.
+
+The VHCI callbacks are the one genuinely cross-thread part, since the controller
+invokes them on its own task. They only write to a mutex-guarded ring buffer
+that the main task drains. (BTstack's port defers via
+`btstack_run_loop_execute_on_main_thread()`, which on the embedded run loop is
+an unlocked list insert -- correct for its FreeRTOS loop, a data race here.)
+
+**Scope of that claim, precisely.** It means BTstack callbacks are on one task.
+It does NOT mean the firmware is single-threaded, and an audit caught the
+original wording implying that. Two other contexts run firmware code:
+`port::timer_once_ms()` dispatches on the **esp_timer task** (priority 22, core
+0) against a main task at priority 1 -- so `status_gpio.cpp`'s callback really
+does preempt -- and the core-1 audio worker is a real task on a real second
+core.
+
+Core allocation follows from the same reasoning. The audio worker's loop never
+blocks, because on RP2350 it owns a bare core. Core 1 is therefore dedicated to
+it, and the BT controller, `esp_timer` and main task are pinned to core 0
+explicitly in `sdkconfig.defaults` rather than left to defaults -- a default
+flipping to core 1 would surface as audio glitching under load.
+
+### Deliberately accepted, with tripwires
+
+Audited and judged safe *as the code stands*. Each has a condition that would
+make it unsafe -- check these before changing the relevant area.
+
+- **TinyUSB's audio class driver runs in the dwc2 ISR** (`audiod_xfer_isr`,
+  `audiod_sof_isr`), unlike HID. Safe only because no firmware code sits on that
+  call graph and tu_fifo is SPSC-correct with the main task as sole producer of
+  `ep_in_ff` / sole consumer of `ep_out_ff`.
+  **Tripwire:** implementing any `tud_audio_*_done_*` callback, adding a second
+  `tud_audio_write` site, or calling `tud_audio_clear_ep_in_ff` puts firmware
+  state under interrupt preemption -- and `audiod_init` never calls
+  `tu_fifo_config_mutex`, so the FIFO lock is a no-op.
+- **The core-1 worker spins at priority 23 and never yields**, so core 1's idle
+  task never runs. Deliberate. The only thing that must still preempt it is the
+  IPC task used by the flash cache-disable path, at priority 24 -- one level
+  above.
+  **Tripwire:** any task pinned to core 1 below priority 23 will silently never
+  run.
+- **The HCI RX ring drops rather than applying back-pressure** (no
+  `ENABLE_HCI_CONTROLLER_TO_HOST_FLOW_CONTROL`). The ring holds roughly 350 ms
+  of traffic against a worst-case main-task stall of 150 ms, so ~2.3x margin.
+  Note `kAclPacketNum = 8` is worst-case *byte* sizing, not a slot count.
+  Drops are counted and reported from `bt_transport_poll()`.
+- **The hot path runs from RAM, at the cost of DIRAM that is shared with the
+  heap.** `PORT_FAST_FUNC` maps to `IRAM_ATTR` and covers firmware code
+  (`audio_loop`, `speaker_proc`, `mic_proc`, `interrupt_loop`, both packet
+  handlers). Submodule code cannot take the attribute, so `main/ds5_hot_iram.lf`
+  maps it instead -- the ESP-IDF counterpart of the RP2350 build's Phase B.2-B.4
+  objcopy renames, same function list, first-class mechanism. Verified in the map:
+  btstack's `packet_handler`, `hci_run`, `l2cap_acl_handler`, `l2cap_run`, the
+  send paths and list iterators, plus TinyUSB's `tud_task_ext`, `tu_fifo_*`,
+  `dcd_edpt_xfer`, `audiod_xfer_isr` and the HID report tail all sit in DIRAM
+  (0x2F000000-0x2F080000). Cost 24.5 KB, leaving 277 KB / 55% of DIRAM free.
+  **Tripwire:** DIRAM is shared with the heap, so every function added to that
+  fragment comes out of the allocator. It is scoped to the audio/BT per-packet
+  path on purpose; `state_update` and the rest of the host->controller rumble/LED
+  path stay in flash, exactly as on the Pico.
+- **A flash erase or write disables the cache for both cores**, so anything still
+  at 0x4001xxxx stalls for its duration -- `bt_task`, `config_save`, most of the
+  BT host outside the relocated set. The audio and per-packet paths survive
+  because they are in RAM. `SOC_SPI_MEM_SUPPORT_AUTO_SUSPEND` is 1 on this chip
+  but `CONFIG_SPI_FLASH_AUTO_SUSPEND` is off, so nothing shortens that stall
+  today.
+  **Tripwire:** if a config save from the web UI, or a blacklist persist, ever
+  glitches audio, the levers in order are that Kconfig option, then registering
+  the USB interrupt with `ESP_INTR_FLAG_IRAM` (which additionally requires every
+  callee on the ISR path to be IRAM-resident), then widening the fragment.
+
+### Latent defects this port surfaced, deliberately NOT changed on RP2350
+
+Several defects here were never ESP32 problems. The firmware was doing the wrong
+thing already; the S31 is simply less forgiving than the CYW43439 and turned each
+one into a visible failure.
+
+**None of these are fixed on RP2350, and that is deliberate.** That target works
+today, has years of field use behind it, and its current shape may encode
+workarounds for problems earlier maintainers hit and did not write down.
+Changing it to satisfy a defect that only manifests on different silicon trades
+a known-good target for a theoretical improvement. Each is guarded to ESP32-S31
+and recorded here so the reasoning survives -- not as a work list.
+
+If one of these is ever pursued upstream, the notes below include what to watch
+for, and in the `l2cap_send()` case an explicit trap to avoid.
+
+Should anyone revisit that decision, test each in isolation, and after every one:
+fresh PS+Share pair, PS-button reconnect, USB enumeration, speaker, mic.
+
+- **Duplicate HCI commands** (`src/bt.cpp`, guards around the link key
+  reply in both branches, user confirmation, `hci_set_connection_encryption`,
+  and `hci_accept_connection_request`). BTstack already sends all of these from
+  `hci_run()`; the application sent them again. CYW43439 rejects the second with
+  `0x0C` Command Disallowed and continues, so the fault is invisible there. The
+  ESP32-S31 controller asserted in `olm_lmp_ssp.c:1820` and reset. Highest
+  priority of these: it is the same class of defect that crashed one controller
+  outright, and there is no reason to assume that controller is the last one
+  this firmware meets. Watch for: pairing completing normally, and no change to
+  reconnect.
+- **Page scan violates the interlaced-scan rule** (`src/bt.cpp`,
+  `gap_set_page_scan_activity(0x0012, 0x0012)` alongside
+  `PAGE_SCAN_MODE_INTERLACED`). Core Spec 5.4, Vol 2 Part B 8.3.1: "If the scan
+  interval is not at least twice the scan window, then generalized interlaced
+  scan shall not be used" -- an interlaced scan is two back-to-back windows, so
+  equal interval and window leaves the second nowhere to go. Neither HCI command
+  can reject it, so both return success and the controller is silently
+  misconfigured. Equal values are also R0, a 100% duty cycle, which the same
+  section warns starves anything sharing the radio -- including the LMP exchanges
+  of a link still forming. Changed to 0x50/0x12 on ESP32-S31 only, matching what
+  BlueRetro ships; Linux uses 0x0100/0x0012 for interlaced and the Bluetooth
+  default is 0x0800/0x0012. Watch for: reconnect latency, since this lowers page
+  scan duty from 100% to 22%.
+
+  On ESP32-S31 this is the change that made reconnect-after-PS-hold reliable,
+  confirmed by reverting the other candidate independently (below). Duty cycle
+  went DOWN and reliability went UP, which is the tell that the 100% scan was
+  starving the LMP exchange of the link it was supposed to be accepting.
+- **`l2cap_send()` status discarded** (`control_send()` in `src/bt.cpp`).
+  It returns `BUFFERS_FULL` when the controller has no free ACL buffer, and the
+  return value is dropped. `init_feature()` issues four requests back to back,
+  so on the ESP32-S31 three vanished silently -- including 0x05 calibration and
+  0x20 firmware version. CYW43439 has buffers enough that the burst fits, so the
+  bug is latent rather than absent.
+
+  Do NOT simply un-guard the ESP32 fix. Deferring these sends into a FIFO is
+  what broke the RP2350 once already: the 0x20 reply drives the
+  "Connected DS5 Controller" branch, the only caller of `tud_connect()`, so the
+  gamepad paired and the USB device never appeared. If this is fixed for both,
+  fix it by checking the status and retrying, not by deferring the send.
+
+### Investigated and reverted
+
+- **Disabling inquiry scan.** `gap_discoverable_control(0)` was set on
+  ESP32-S31, reasoning that a bonded controller pages us rather than discovering
+  us, and that neither Bluepad32 nor BlueRetro enable inquiry scan. It went in
+  alongside the page scan change while reconnect was broken, and reconnect
+  started working, so it looked load-bearing. It was not: reverting it alone,
+  with the page scan fix kept, left reconnect just as reliable. That part is
+  settled and visible in any reconnect log.
+
+  **The lightbar conclusion drawn from the same test was wrong.** That build
+  also had `DS5_FEATURE_TRACE=1`, whose blocking `printf`s sit on the output
+  report path, so the lightbar working was not attributable to the inquiry scan
+  change it was meant to test. With the trace off the symptom returned and the
+  `ResetLights` pulse had to be restored. See the lightbar entry above -- it is a
+  real platform behaviour, not a bug of our own making.
+
+  Three lessons, all paid for in hardware test cycles:
+
+  - Changing two radio settings in one build to fix one symptom means neither is
+    attributed, and the unattributed one is free to cause the next bug.
+  - A test only isolates the variable you changed *deliberately*. Diagnostic
+    output is a variable: it costs milliseconds on the path being measured, and
+    it silently differed between the build that passed and the build that
+    shipped.
+  - Verify the shipping configuration, not a near neighbour of it. Confirming
+    with tracing on and then shipping with it off is not a verification.
+
+### Not done
+
+- ~~Preemption assumptions need auditing.~~ Done. A four-lens adversarial audit
+  confirmed the BTstack-callbacks-on-one-task claim by tracing all four
+  `bt_write()` callers, and found five real defects, all fixed: a timer
+  use-after-free, blocking `printf` on two must-not-block contexts, a
+  two-consumer race on `audio_spk_fifo`, a non-atomic `mic_active`, and a
+  `CFG_TUSB_OS` mismatch between the app and the TinyUSB library. One
+  behavioural change fell out: `audio_spk_fifo` overflow now drops the newest
+  frame rather than the oldest, on both targets.
+- **The status GPIO is not configurable here, and the pin model is not
+  target-aware anywhere.** `status_gpio_pin_valid()` excludes UART, VSYS/VBUS,
+  SMPS and CYW43 pins through `#ifdef PICO_*` guards, all of which compile out
+  on this target, so the ESP32 accepts any pin below `SOC_GPIO_PIN_COUNT` --
+  including ones the board already uses (status LED 60, BOOT button 61) and
+  strapping pins. The web config compounds it: its selector offers Pico 2 W
+  GPIOs and rejects anything else, so a stored pin of 0 is reported back as
+  invalid and the page refuses the config.
+
+  This is not specific to the ESP32. `waveshare_rp2350b_plus_w` is RP2350**B**
+  with 48 GPIOs against the Pico 2 W's 30 (`PICO_RP2350A 0` in its board
+  header), so that target already accepts pins 30-47 the web config will never
+  offer, with its reserved pins at different numbers. One hardcoded pin list is
+  serving three different maps.
+
+  A real fix is three parts: the firmware reports its target (a new report
+  alongside `0xf8`/`0xf9` is cheaper than a `Config_body` field, which would
+  mean a `CONFIG_VERSION` bump and a migration), the web config carries a pin
+  map per target, and `status_gpio_pin_valid()` gets a port hook instead of
+  more `#ifdef`s. Part of that lives in the web config repo, so it is not
+  self-contained here.
+
+  Deliberately deferred. The S31 is a development board, not something anyone
+  buys to run this firmware, and the GPIO header is not the reason to use it.
+  Worth doing when dongle-style boards exist that people actually wire things
+  to -- at which point the Waveshare target needs it too.
+- **`reboot_to_bootloader()` falls back to a plain restart.** For S31 this is
+  `LP_SYSTEM_REG_SYS_CTRL_REG` bit 2 `FORCE_DOWNLOAD_BOOT` (P4-style LP_SYSTEM,
+  not the S3's `RTC_CNTL`) followed by a reset. Unverified — confirm against the
+  S31 TRM before trusting it.
+- `ram_mem.c`'s memcpy/memset overrides are carried over unchanged; whether they
+  still pay for themselves against ESP32-S31 IRAM placement is untested.

--- a/ports/esp32s31/components/btstack/CMakeLists.txt
+++ b/ports/esp32s31/components/btstack/CMakeLists.txt
@@ -1,0 +1,75 @@
+# BTstack as an ESP-IDF component, from the lib/btstack submodule. Adapted from
+# BTstack's port/esp32 component with two deliberate differences:
+#
+#  1. src/classic is built unconditionally. Upstream gates it on
+#     CONFIG_IDF_TARGET_ESP32; the S31 also has BR/EDR, and without this the
+#     DualSense cannot connect at all.
+#  2. btstack_config.h resolves to the firmware's own src/btstack_config.h, so
+#     both targets share one stack configuration.
+#
+# BTstack is the host; ESP-IDF supplies only the controller, reached over VHCI.
+
+set(BTSTACK_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../../lib/btstack")
+set(FW_SRC "${CMAKE_CURRENT_LIST_DIR}/../../../../src")
+set(ESP32_PORT "${BTSTACK_ROOT}/port/esp32/components/btstack")
+
+file(GLOB btstack_srcs
+    "${BTSTACK_ROOT}/src/*.c"
+    "${BTSTACK_ROOT}/src/classic/*.c"
+    "${BTSTACK_ROOT}/platform/embedded/btstack_run_loop_embedded.c"
+    "${BTSTACK_ROOT}/platform/embedded/hci_dump_embedded_stdout.c"
+    "${BTSTACK_ROOT}/3rd-party/micro-ecc/uECC.c"
+    "${BTSTACK_ROOT}/3rd-party/md5/md5.c"
+    "${BTSTACK_ROOT}/3rd-party/yxml/yxml.c"
+)
+
+# Only the NVS-backed TLV is taken from BTstack's ESP32 port, for link-key
+# storage. btstack_port_esp32.c is deliberately NOT built: it hardwires the
+# FreeRTOS run loop, whose execute() never returns and so cannot coexist with
+# main.cpp's superloop. src/port/esp32s31/bt_transport_esp32s31.cpp supplies a
+# VHCI transport driving the pollable embedded run loop instead.
+# btstack_audio_esp32_*.c and es8388.c drive BTstack's own I2S audio path, which
+# this firmware does not use -- it owns its audio pipeline in src/audio.cpp.
+list(APPEND btstack_srcs
+    "${ESP32_PORT}/btstack_tlv_esp32.c"
+)
+
+idf_component_register(
+    SRCS ${btstack_srcs}
+    INCLUDE_DIRS
+        # FW_SRC must come FIRST. The bundled port/esp32 btstack_config.h only
+        # defines ENABLE_CLASSIC under CONFIG_IDF_TARGET_ESP32 and is BLE-only
+        # everywhere else -- on ESP32-S31 that silently drops BR/EDR and the
+        # Classic sources then fail to find their memory pools. Every TU must
+        # also agree on one config, or struct layouts diverge across the build.
+        "${FW_SRC}"
+        "${BTSTACK_ROOT}/src"
+        "${BTSTACK_ROOT}/src/classic"
+        "${BTSTACK_ROOT}/platform/embedded"
+        "${BTSTACK_ROOT}/3rd-party/md5"
+        "${BTSTACK_ROOT}/3rd-party/yxml"
+        # btstack_lc3_google.c is swept up by the src/*.c glob. LC3 is LE Audio,
+        # which this Classic-only firmware never calls, so the header is enough
+        # -- the archive member is simply never pulled in at link time.
+        "${BTSTACK_ROOT}/3rd-party/lc3-google/include"
+        # Same story for SBC: btstack_sbc_bluedroid.c is globbed in, A2DP is
+        # unused, so the headers satisfy the compiler and the linker drops it.
+        "${BTSTACK_ROOT}/3rd-party/bluedroid/encoder/include"
+        "${BTSTACK_ROOT}/3rd-party/bluedroid/decoder/include"
+        "${ESP32_PORT}/include"
+    PRIV_INCLUDE_DIRS
+        "${BTSTACK_ROOT}/3rd-party/micro-ecc"
+    PRIV_REQUIRES
+        nvs_flash
+        bt
+        driver
+        vfs
+)
+
+# BTstack is vendored third-party code built with the project's warning flags,
+# which are stricter than upstream's. Downgrade rather than patch the submodule.
+target_compile_options(${COMPONENT_LIB} PRIVATE
+    -Wno-error=maybe-uninitialized
+    -Wno-maybe-uninitialized
+)
+

--- a/ports/esp32s31/components/libopus/CMakeLists.txt
+++ b/ports/esp32s31/components/libopus/CMakeLists.txt
@@ -1,0 +1,26 @@
+# libopus as an ESP-IDF component.
+#
+# Reuses the lib/opus submodule that the Pico build compiles via
+# add_subdirectory, rather than vendoring a second copy. The upstream opus
+# CMakeLists builds a target named `opus`; this component wraps it.
+#
+# Float mode, matching the Pico build (OPUS_FIXED_POINT is commented out in the
+# top-level CMakeLists.txt). ESP32-S31 is dual-core RISC-V at 240MHz with an
+# FPU, so float remains the right choice; opus falls back to its generic C paths
+# with no RISC-V intrinsics.
+
+set(OPUS_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../../lib/opus")
+
+idf_component_register(INCLUDE_DIRS "${OPUS_DIR}/include")
+
+# Keep the upstream build to just the library.
+set(OPUS_BUILD_SHARED_LIBRARY OFF CACHE BOOL "" FORCE)
+set(OPUS_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+set(OPUS_BUILD_PROGRAMS OFF CACHE BOOL "" FORCE)
+set(OPUS_INSTALL_PKG_CONFIG_MODULE OFF CACHE BOOL "" FORCE)
+set(OPUS_INSTALL_CMAKE_CONFIG_MODULE OFF CACHE BOOL "" FORCE)
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+
+add_subdirectory("${OPUS_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/opus_build" EXCLUDE_FROM_ALL)
+
+target_link_libraries(${COMPONENT_LIB} INTERFACE opus)

--- a/ports/esp32s31/components/wdl_resampler/CMakeLists.txt
+++ b/ports/esp32s31/components/wdl_resampler/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Cockos WDL resampler as an ESP-IDF component.
+#
+# One translation unit. -fsigned-char matches the Pico build; WDL's resampler
+# assumes signed char, and RISC-V (like ARM) defaults to unsigned.
+
+set(WDL_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../../lib/WDL/WDL")
+
+idf_component_register(
+    SRCS "${WDL_DIR}/resample.cpp"
+    INCLUDE_DIRS "${WDL_DIR}"
+)
+
+target_compile_options(${COMPONENT_LIB} PRIVATE -fsigned-char)
+target_compile_definitions(${COMPONENT_LIB} PUBLIC WDL_RESAMPLE_TYPE=float)

--- a/ports/esp32s31/dependencies.lock
+++ b/ports/esp32s31/dependencies.lock
@@ -1,0 +1,38 @@
+dependencies:
+  espressif/led_strip:
+    component_hash: 28621486f77229aaf81c71f5e15d6fbf36c2949cf11094e07090593e659e7639
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 3.0.3
+  espressif/tinyusb:
+    component_hash: a72b7d67472914ab76309340fd50d578b31e310963d45ad0f81144bde3314752
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    targets:
+    - esp32s2
+    - esp32s3
+    - esp32p4
+    - esp32h4
+    - esp32s31
+    version: 0.21.0~1
+  idf:
+    source:
+      type: idf
+    version: 6.2.0
+direct_dependencies:
+- espressif/led_strip
+- espressif/tinyusb
+- idf
+manifest_hash: fbeb52248c5a38923d54a712f259b6f4268701629af4bade43d50661167c1368
+target: esp32s31
+version: 3.0.0

--- a/ports/esp32s31/main/CMakeLists.txt
+++ b/ports/esp32s31/main/CMakeLists.txt
@@ -1,0 +1,96 @@
+# Shared firmware sources plus the ESP32-S31 backend. The file list mirrors the
+# ds5-bridge target in the top-level CMakeLists.txt; keep the two in step.
+
+set(SRC_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../src")
+
+# Reported to the config UI over HID report 0xf8. Overridable the same way as
+# the RP2350 build's -DVERSION, so release builds of the two targets can agree.
+set(VERSION "dev" CACHE STRING "Program version string")
+
+idf_component_register(
+    LDFRAGMENTS "ds5_hot_iram.lf"
+    SRCS
+        "${CMAKE_CURRENT_LIST_DIR}/app_main.cpp"
+        "${SRC_DIR}/usb_descriptors.cpp"
+        "${SRC_DIR}/main.cpp"
+        "${SRC_DIR}/usb.cpp"
+        "${SRC_DIR}/audio.cpp"
+        "${SRC_DIR}/bt.cpp"
+        "${SRC_DIR}/button_functions.cpp"
+        "${SRC_DIR}/dse.cpp"
+        "${SRC_DIR}/config.cpp"
+        "${SRC_DIR}/status_gpio.cpp"
+        "${SRC_DIR}/cmd.cpp"
+        "${SRC_DIR}/ram_mem.c"
+        "${SRC_DIR}/battery_led.cpp"
+        "${SRC_DIR}/wake.cpp"
+        "${SRC_DIR}/ps_shortcut.cpp"
+        "${SRC_DIR}/port/esp32s31/port_esp32s31.cpp"
+        "${SRC_DIR}/port/esp32s31/bt_transport_esp32s31.cpp"
+    INCLUDE_DIRS
+        "${SRC_DIR}"
+        "${SRC_DIR}/port/esp32s31"
+    REQUIRES
+        driver
+        esp_timer
+        esp_partition
+        esp_system  # also provides esp_task_wdt.h
+        esp_hw_support  # esp_private/usb_phy.h
+        bt
+        espressif__led_strip
+        espressif__tinyusb
+        btstack
+        libopus
+        wdl_resampler
+)
+
+# ram_mem.c overrides memcpy/memset/memmove to keep them out of flash. On
+# ESP32-S31 the equivalent win comes from IRAM placement via PORT_FAST_FUNC.
+target_compile_definitions(${COMPONENT_LIB} PRIVATE
+    ENABLE_CLASSIC=1
+    # Uncomment to dump every HCI packet from ACL connect onwards (the hook is
+    # in bt.cpp, guarded on this symbol). Invaluable for connection-setup bugs,
+    # but do NOT leave it on once HID reports start flowing: each report becomes
+    # a blocking hexdump on a 115200 console, which stalls the main loop long
+    # enough to trip the task watchdog.
+    # DS5_HCI_DUMP=1
+    # Uncomment for per-stage speaker-path counters (usb -> audio_fifo -> opus ->
+    # Bluetooth), one line/sec while audio is moving. The hook is in audio.cpp.
+    # This is what localised the silent speaker to the USB stage rather than the
+    # codec or the link, so it is worth keeping around.
+    # DS5_AUDIO_STATS=1
+    # Traces feature-report requests and replies, and when the lightbar/state
+    # output report goes out. A few lines per connect. Here to establish whether
+    # the DualSense has answered 0x05 (calibration) before we try to drive its
+    # lights -- it ignores full output reports over Bluetooth until it has.
+    # DS5_FEATURE_TRACE=1
+    ENABLE_BATT_LED=1
+    ENABLE_SERIAL=0
+    ENABLE_DEBUG=0
+    ENABLE_VERBOSE=0
+    ENABLE_WAKE_HID
+    DISABLE_SPEAKER_PROC=0
+    WDL_RESAMPLE_TYPE=float
+    DS5_FIRMWARE_VERSION="${VERSION}"
+    # CFG_TUSB_MCU / CFG_TUSB_OS are set globally in ../CMakeLists.txt so the
+    # application and the TinyUSB library cannot disagree about them.
+)
+
+set_source_files_properties("${SRC_DIR}/ram_mem.c" PROPERTIES
+    COMPILE_FLAGS "-fno-builtin")
+
+# IDF builds with a stricter warning set than the Pico toolchain, and these two
+# fire inside TinyUSB's headers and the existing descriptor tables rather than
+# in new code. Downgraded so the port does not churn shared sources.
+target_compile_options(${COMPONENT_LIB} PRIVATE
+    -Wno-error=missing-field-initializers
+    -Wno-error=volatile
+    -Wno-error=comment
+    # WDL's wdltypes.h static-asserts that char is signed.
+    -fsigned-char
+)
+
+# TinyUSB calls back into this component (tud_descriptor_*_cb,
+# tud_hid_descriptor_report_cb), but nothing in the dependency graph points that
+# way, so the linker discards those objects before TinyUSB's archive is scanned.
+idf_component_set_property(main WHOLE_ARCHIVE ON)

--- a/ports/esp32s31/main/app_main.cpp
+++ b/ports/esp32s31/main/app_main.cpp
@@ -1,0 +1,14 @@
+// ESP-IDF entry point.
+//
+// The shared firmware keeps a conventional int main() (src/main.cpp), which
+// runs the USB/BT service loop and never returns. ESP-IDF's FreeRTOS startup
+// calls app_main() on the main task instead, so bridge the two here rather than
+// making the shared source care which platform it is on.
+//
+// The main task's stack comes from CONFIG_ESP_MAIN_TASK_STACK_SIZE.
+
+extern int main();
+
+extern "C" void app_main(void) {
+    main();
+}

--- a/ports/esp32s31/main/ds5_hot_iram.lf
+++ b/ports/esp32s31/main/ds5_hot_iram.lf
@@ -1,0 +1,55 @@
+# Hot-path code moved from flash to internal RAM -- the ESP-IDF counterpart of
+# the RP2350 build's relocations, same function list. noflash_text rather than
+# noflash because symbol granularity only works for text; rodata stays in flash.
+#
+# Costs 22.7 KB of DIRAM, which is shared with the heap, so anything added here
+# comes out of the allocator. Keep it to the audio/BT per-packet path -- the
+# rumble/LED path is deliberately absent, as on the Pico.
+
+[mapping:ds5_btstack_hot]
+archive: libbtstack.a
+entries:
+    # Per-packet receive: the HCI event/ACL demux and the L2CAP ACL handler.
+    hci:packet_handler (noflash_text)
+    l2cap:l2cap_acl_handler (noflash_text)
+    # TX pumps and the send paths they drive.
+    hci:hci_run (noflash_text)
+    hci:hci_send_acl_packet_fragments (noflash_text)
+    hci:hci_send_acl_packet_buffer (noflash_text)
+    l2cap:l2cap_run (noflash_text)
+    l2cap:l2cap_send (noflash_text)
+    l2cap:l2cap_send_prepared (noflash_text)
+    l2cap:l2cap_notify_channel_can_send (noflash_text)
+    l2cap:l2cap_request_can_send_now_event (noflash_text)
+    # Walked by every run of the pumps above.
+    btstack_linked_list:btstack_linked_list_iterator_init (noflash_text)
+    btstack_linked_list:btstack_linked_list_iterator_has_next (noflash_text)
+    btstack_linked_list:btstack_linked_list_iterator_next (noflash_text)
+    # Run loop poll, called from the main loop every iteration.
+    btstack_run_loop:btstack_run_loop_base_poll_data_sources (noflash_text)
+    btstack_run_loop_embedded:btstack_run_loop_embedded_execute_once (noflash_text)
+
+[mapping:ds5_tinyusb_hot]
+archive: libespressif__tinyusb.a
+entries:
+    # FIFO data path, shared by the audio and HID endpoints.
+    tusb_fifo:tu_fifo_read_n_access_mode (noflash_text)
+    tusb_fifo:tu_fifo_write_n_access_mode (noflash_text)
+    # Device task pump and per-transfer submit.
+    usbd:tud_task_ext (noflash_text)
+    usbd:usbd_edpt_xfer (noflash_text)
+    usbd:usbd_edpt_xfer_fifo (noflash_text)
+    # The ISR that drives every path below it, left in flash when the rest of
+    # the hot path moved to RAM.
+    dcd_dwc2:dcd_int_handler (noflash_text)
+    usbd:dcd_event_handler (noflash_text)
+    dcd_dwc2:dcd_edpt_xfer (noflash_text)
+    dcd_dwc2:dcd_edpt_iso_activate (noflash_text)
+    # Audio class data path, including the ISR half.
+    audio_device:tud_audio_n_read (noflash_text)
+    audio_device:tud_audio_n_write (noflash_text)
+    audio_device:audiod_xfer_isr (noflash_text)
+    # Input-report path tail, controller -> host.
+    hid_device:tud_hid_n_report (noflash_text)
+    hid_device:tud_hid_n_ready (noflash_text)
+    hid_device:hidd_xfer_cb (noflash_text)

--- a/ports/esp32s31/main/idf_component.yml
+++ b/ports/esp32s31/main/idf_component.yml
@@ -1,0 +1,14 @@
+dependencies:
+  idf:
+    version: ">=6.0"
+  # Addressable RGB status LED on GPIO60 (see board_esp32s31.h).
+  espressif/led_strip:
+    version: "^3.0.0"
+  # Raw TinyUSB, NOT espressif/esp_tinyusb. The wrapper ships its own
+  # tusb_config.h on a public include path, which shadows the firmware's
+  # src/tusb_config.h and silently disables the device stack. This firmware
+  # supplies its own descriptors, config and tud_* callbacks, so it wants
+  # TinyUSB unwrapped. 0.21.0 matches the 4-argument TUD_AUDIO_EP_SIZE the
+  # pinned Pico SDK TinyUSB uses.
+  espressif/tinyusb:
+    version: "~0.21.0"

--- a/ports/esp32s31/partitions.csv
+++ b/ports/esp32s31/partitions.csv
@@ -1,0 +1,12 @@
+# Partition table for the 16MB flash on ESP32-S31-WROOM-3.
+#
+# The "config" entry is the ESP32 equivalent of the last-flash-sector config
+# region the RP2350 build uses. Keep its size in step with
+# port::kConfigStorageSize in src/port/esp32s31/port_flash_impl.h.
+#
+# Name,     Type, SubType,  Offset,   Size,   Flags
+nvs,        data, nvs,      0x9000,   0x6000,
+phy_init,   data, phy,      0xf000,   0x1000,
+factory,    app,  factory,  0x10000,  4M,
+config,     data, 0x40,     ,         0x1000,
+btstack,    data, 0x41,     ,         0x4000,

--- a/ports/esp32s31/patches/tinyusb-dwc2-esp32s31.patch
+++ b/ports/esp32s31/patches/tinyusb-dwc2-esp32s31.patch
@@ -1,0 +1,114 @@
+--- a/src/portable/synopsys/dwc2/dcd_dwc2.c	2026-09-08 16:10:31.412486303 -0400
++++ b/src/portable/synopsys/dwc2/dcd_dwc2.c	2026-09-08 19:34:34.839194647 -0400
+@@ -52,6 +52,7 @@
+   uint16_t total_len;
+   uint16_t max_size;
+   uint8_t interval;
++  uint16_t iso_target_frame; // (micro)frame this ISO transfer was armed for
+   uint8_t iso_retry; // ISO retry counter
+ } xfer_ctl_t;
+ 
+@@ -398,11 +399,19 @@
+   depctl.enable = 1;
+   if (depctl.type == DEPCTL_EPTYPE_ISOCHRONOUS) {
+     const dwc2_dsts_t dsts = {.value = dwc2->dsts};
+-    const uint32_t odd_now = dsts.frame_number & 1u;
+-    if (odd_now != 0) {
+-      depctl.set_data0_iso_even = 1;
+-    } else {
++    // Target the (micro)frame this endpoint is next scheduled in -- one
++    // interval away, not simply the next one. The two coincide only at
++    // interval 1, so this is invisible at full speed with bInterval 1 and wrong
++    // at high speed with bInterval 4: that is 8 microframes, so the target has
++    // the same parity, not the opposite. Get it wrong and the core waits for a
++    // slot that never matches and abandons the transfer. xfer->interval is
++    // already in frame_number units (see edpt_activate).
++    const uint32_t target = dsts.frame_number + xfer->interval;
++    xfer->iso_target_frame = (uint16_t) (target & 0x3FFFu);
++    if (target & 1u) {
+       depctl.set_data1_iso_odd = 1;
++    } else {
++      depctl.set_data0_iso_even = 1;
+     }
+   }
+ 
+@@ -727,7 +736,17 @@
+ 
+   // Clear stall and reset data toggle
+   dep->ctl &= ~EPCTL_STALL;;
+-  dep->ctl |= EPCTL_SD0PID_SEVNFRM;
++
++  // On an isochronous endpoint EPCTL_SD0PID_SEVNFRM is not a data toggle -- it
++  // is SetEvenFrame, which retargets an already-armed transfer at an even
++  // (micro)frame. Windows sends CLEAR_FEATURE(ENDPOINT_HALT) on the iso OUT
++  // endpoint immediately before it starts streaming, so applying it there
++  // overwrites the parity the transfer was armed with, and when the target
++  // frame is odd the core aborts the transfer and disables the endpoint.
++  const dwc2_depctl_t clr_depctl = {.value = dep->ctl};
++  if (clr_depctl.type != DEPCTL_EPTYPE_ISOCHRONOUS) {
++    dep->ctl |= EPCTL_SD0PID_SEVNFRM;
++  }
+ }
+ 
+ //--------------------------------------------------------------------
+@@ -1176,9 +1195,45 @@
+   Note: when OTG_MULTI_PROC_INTRPT = 1, Device Each endpoint interrupt deachint/deachmsk/diepeachmsk/doepeachmsk
+   are combined to generate dedicated interrupt line for each endpoint.
+  */
++
++// An isochronous OUT transfer that misses its scheduled (micro)frame is left
++// armed but never completes, and the endpoint stays stuck with nothing to
++// restart it -- which is how this port arrived at a silent speaker. Re-arming
++// through edpt_schedule_packets() reuses the normal path, so the parity above
++// is applied the same way. In practice this only fires while a stream is
++// starting up; once running, transfers complete in their target frame.
++static void handle_incomplete_iso_out(uint8_t rhport) {
++  dwc2_regs_t* dwc2 = DWC2_REG(rhport);
++  const dwc2_dsts_t dsts = {.value = dwc2->dsts};
++  const uint8_t ep_count = _dwc2_controller[rhport].ep_count;
++
++  for (uint8_t epnum = 1; epnum < ep_count; epnum++) {
++    const dwc2_depctl_t depctl = {.value = dwc2->epout[epnum].doepctl};
++    if (!depctl.enable || depctl.type != DEPCTL_EPTYPE_ISOCHRONOUS) continue;
++
++    xfer_ctl_t* xfer = XFER_CTL_BASE(epnum, TUSB_DIR_OUT);
++    if (xfer->total_len == 0) continue;
++
++    // diff counts microframes at high speed. The endpoint is armed for a whole
++    // interval, so anything less than one is still in flight -- re-arming there
++    // clobbers a transfer that was about to complete.
++    const uint16_t diff = (uint16_t) (((dsts.frame_number & 0x3FFFu) - xfer->iso_target_frame) & 0x3FFFu);
++    if (diff < xfer->interval || diff > 0x2000u) continue;
++
++    edpt_schedule_packets(rhport, epnum, TUSB_DIR_OUT);
++  }
++}
++
++
+ void dcd_int_handler(uint8_t rhport) {
+   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
+   const uint32_t gintmask = dwc2->gintmsk;
++  // Read RAW first: INCOMPISOOUT is never unmasked, so it would be invisible
++  // below. Observe and clear only -- recovery is what hung this port before.
++  if (dwc2->gintsts & GINTSTS_PXFR_INCOMPISOOUT) {
++    dwc2->gintsts = GINTSTS_PXFR_INCOMPISOOUT;
++    handle_incomplete_iso_out(rhport);
++  }
+   const uint32_t gintsts = dwc2->gintsts & gintmask;
+ 
+   if (gintsts & GINTSTS_USBRST) {
+--- a/src/portable/synopsys/dwc2/dwc2_esp32.h	2026-09-08 18:54:43.739446742 -0400
++++ b/src/portable/synopsys/dwc2/dwc2_esp32.h	2026-09-08 18:54:43.779446738 -0400
+@@ -117,7 +117,11 @@
+ 
+ TU_ATTR_ALWAYS_INLINE static inline void dwc2_int_set(uint8_t rhport, tusb_role_t role, bool enabled) {
+   if (enabled) {
+-    esp_intr_alloc(_dwc2_controller[rhport].irqnum, ESP_INTR_FLAG_LOWMED,
++    // LOWMED takes the lowest free priority (level 1). This ISR has a hard 1 ms
++    // deadline and shares the part with a Bluetooth controller that runs well
++    // above it, so at level 1 it is preempted by most of the system. LEVEL3 is
++    // the highest priority still serviceable by a C handler.
++    esp_intr_alloc(_dwc2_controller[rhport].irqnum, ESP_INTR_FLAG_LEVEL3,
+                    dwc2_int_handler_wrap, (void*)(uintptr_t)tu_u16(role, rhport), &usb_ih[rhport]);
+   } else {
+     esp_intr_free(usb_ih[rhport]);

--- a/ports/esp32s31/sdkconfig.defaults
+++ b/ports/esp32s31/sdkconfig.defaults
@@ -1,0 +1,71 @@
+# ESP32-S31-Function-CoreBoard-1 defaults.
+
+CONFIG_IDF_TARGET="esp32s31"
+
+# --- Flash / PSRAM (ESP32-S31-WROOM-3: 16MB each) ---------------------------
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_SPEED_80M=y
+
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+
+# --- Bluetooth -------------------------------------------------------------
+# The DualSense connects over Bluetooth Classic HID, so BR/EDR is mandatory.
+# Confirmed available on this target: components/soc/esp32s31/include/soc/soc_caps.h
+# defines SOC_BT_CLASSIC_SUPPORTED (1), and the controller ships libbredr_app.a
+# under components/bt/controller/lib_esp32s31/.
+#
+# Controller-only: BTstack is the host, so neither Bluedroid nor NimBLE is built.
+# BTDM_CTRL_MODE_BR_EDR_ONLY is what actually sets BT_CTRL_BREDR_ENABLE --
+# BT_CLASSIC_ENABLED is a Bluedroid host symbol and does nothing here.
+CONFIG_BT_ENABLED=y
+CONFIG_BT_CONTROLLER_ONLY=y
+CONFIG_BTDM_CTRL_MODE_BR_EDR_ONLY=y
+
+# BR/EDR requires an external crystal as RTC slow clock source
+# (components/bt/porting_btdm/Kconfig.in gates on RTC_CLK_SRC_EXT_CRYS).
+CONFIG_RTC_CLK_SRC_EXT_CRYS=y
+
+# --- CPU / scheduling ------------------------------------------------------
+CONFIG_FREERTOS_UNICORE=n
+# 240 MHz deliberately, not by omission -- this part also offers 320, IDF's
+# default here. One DualSense does not need it, and the lower clock costs less
+# power and heat. Revisit for multi-controller work, but it perturbs the same
+# timing-sensitive paths as everything else here, so it needs a hardware pass.
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+
+# Core allocation. The audio worker gets core 1, mirroring the RP2350 build's
+# bare second core, so everything else is pinned to core 0 explicitly rather
+# than left to defaults.
+#
+# The exception is the BT controller, which must NOT share a core with the USB
+# interrupt: esp_intr_alloc registers that interrupt on whichever core calls it
+# (the main task, core 0), and the controller's interrupt-disabling critical
+# sections there stall the isochronous audio endpoint for milliseconds at a
+# time. That puts it on core 1 with the audio worker; verified on hardware for
+# pairing, both reconnect paths, lightbar and audio under load. If BT ever
+# misbehaves under load, the alternative is registering the USB interrupt on
+# core 1 instead, which needs the init path restructured.
+CONFIG_BT_CTRL_PINNED_TO_CORE_CHOICE_1=y
+CONFIG_ESP_TIMER_TASK_AFFINITY_CPU0=y
+CONFIG_ESP_MAIN_TASK_AFFINITY_CPU0=y
+
+# Consequence of the above: core 1's idle task never runs, so it must not be
+# watched.
+CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1=n
+
+# The firmware configures the task watchdog itself (port::watchdog_enable), so
+# do not let IDF initialise it at startup -- that made our esp_task_wdt_init()
+# fail with ESP_ERR_INVALID_STATE and log a spurious error on every boot.
+CONFIG_ESP_TASK_WDT_INIT=n
+
+# 1 ms ticks rather than 10 ms. The audio path works in sub-millisecond
+# deadlines, and the coarse default makes every scheduler-mediated wait far too
+# blunt to be useful.
+CONFIG_FREERTOS_HZ=1000
+
+# --- Performance -----------------------------------------------------------
+CONFIG_COMPILER_OPTIMIZATION_PERF=y

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -8,6 +8,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#include <atomic>
+#include "port/port.h"
 #include "audio.h"
 #include "bt.h"
 #if ENABLE_DEBUG
@@ -20,9 +22,6 @@
 #include <cstdio>
 #include "opus.h"
 #include "utils.h"
-#include "pico/multicore.h"
-#include "pico/flash.h"
-#include "pico/util/queue.h"
 #include "config.h"
 
 #define INPUT_CHANNELS    4
@@ -44,13 +43,17 @@ static WDL_Resampler resampler;
 extern uint8_t reportSeqCounter;
 extern uint8_t packetCounter;
 static bool plug_headset = false;
-static bool mic_active = false; // host has opened the mic IN interface (alt != 0)
+// Written on the main task (set_mic_active), read on the core-1 audio worker.
+// Genuinely concurrent on both targets -- two real cores -- so not a plain bool.
+static std::atomic<bool> mic_active{false}; // host has opened the mic IN interface (alt != 0)
 alignas(8) static uint32_t audio_core1_stack[7000];
-queue_t audio_fifo; // raw pcm data
-queue_t mic_fifo;
-queue_t mic_decode_fifo;
-queue_t audio_spk_fifo; // opus data
-queue_t haptics_fifo;
+port::Queue audio_fifo; // raw pcm data
+port::Queue mic_fifo;
+port::Queue mic_decode_fifo;
+port::Queue audio_spk_fifo; // opus data
+// Incremented on the audio worker, drained by the main task for reporting.
+static volatile uint32_t audio_spk_overrun_count = 0;
+port::Queue haptics_fifo;
 
 struct audio_raw_element {
     float data[512 * 2];
@@ -99,18 +102,47 @@ void update_mic_status() {
     bt_write(pkt, sizeof(pkt));
 }
 
-void __not_in_flash_func(audio_bt_task)() {
+#if defined(DS5_AUDIO_STATS)
+// Per-stage counters for the speaker path, so a silent speaker can be pinned to
+// a stage instead of guessed at. The chain is:
+//   USB iso OUT -> audio_fifo -> speaker_proc (core 1, resample+opus)
+//                             -> audio_spk_fifo -> audio_bt_task -> BT
+// Printed once a second, and only while something is moving, so an idle console
+// stays readable.
+static uint32_t stat_usb_bytes = 0;    // bytes taken off the USB OUT endpoint
+static uint32_t stat_fifo_drop = 0;    // dropped because audio_fifo was full
+static uint32_t stat_opus_frames = 0;  // opus frames produced on core 1
+static uint32_t stat_bt_pkts = 0;      // 0x32 reports handed to bt_write()
+static uint32_t stat_bt_with_audio = 0;// ...of those, ones carrying speaker data
+
+static void audio_stats_tick() {
+    static uint32_t last_ms = 0;
+    static uint32_t last_total = 0;
+    const uint32_t now = port::now_ms();
+    if (now - last_ms < 1000) return;
+    last_ms = now;
+    const uint32_t total = stat_usb_bytes + stat_bt_pkts;
+    if (total == last_total) return;
+    last_total = total;
+    printf("[AUDIO] usb=%luB drop=%lu opus=%lu bt=%lu (with audio %lu)\n",
+           (unsigned long) stat_usb_bytes, (unsigned long) stat_fifo_drop,
+           (unsigned long) stat_opus_frames, (unsigned long) stat_bt_pkts,
+           (unsigned long) stat_bt_with_audio);
+}
+#endif
+
+void PORT_FAST_FUNC(audio_bt_task)() {
     const Config_body &cfg = get_config();
     const bool mic_enabled = mic_active && cfg.mic_select != 3;
 #if !DISABLE_SPEAKER_PROC
     const bool speaker_enabled = cfg.speaker_select != 3;
 #endif
 
-    if (queue_get_level(&haptics_fifo) < 2) {
+    if (haptics_fifo.level() < 2) {
         return;
     }
 #if !DISABLE_SPEAKER_PROC
-    if (speaker_enabled && queue_get_level(&audio_spk_fifo) < 2) {
+    if (speaker_enabled && audio_spk_fifo.level() < 2) {
         return;
     }
 #endif
@@ -136,13 +168,13 @@ void __not_in_flash_func(audio_bt_task)() {
     pkt[10] = 0x12 | 1 << 6 | 1 << 7;
     pkt[11] = SAMPLE_SIZE;
     static haptics_element haptics_pb{};
-    if (queue_get_level(&haptics_fifo) >= 2) {
-        if (queue_try_remove(&haptics_fifo, &haptics_pb)) {
+    if (haptics_fifo.level() >= 2) {
+        if (haptics_fifo.try_remove(&haptics_pb)) {
             memcpy(pkt + 12, haptics_pb.data,SAMPLE_SIZE);
         } else {
             printf("[Audio] Warning: Haptics queue remove failed\n");
         }
-        if (queue_try_remove(&haptics_fifo, &haptics_pb)) {
+        if (haptics_fifo.try_remove(&haptics_pb)) {
             memcpy(pkt + 12 + SAMPLE_SIZE, haptics_pb.data,SAMPLE_SIZE);
         } else {
             printf("[Audio] Warning: Haptics queue remove failed\n");
@@ -156,13 +188,13 @@ void __not_in_flash_func(audio_bt_task)() {
             ) ? 0x16 : 0x13) | 1 << 6 | 1 << 7;
         pkt[141] = SPEAKER_OPUS_SIZE;
         static audio_spk_element spk_pb{};
-        if (queue_get_level(&audio_spk_fifo) >= 2) {
-            if (queue_try_remove(&audio_spk_fifo, &spk_pb)) {
+        if (audio_spk_fifo.level() >= 2) {
+            if (audio_spk_fifo.try_remove(&spk_pb)) {
                 memcpy(pkt + 142, spk_pb.data,SPEAKER_OPUS_SIZE);
             } else {
                 printf("[Audio] Warning: Speaker queue remove failed\n");
             }
-            if (queue_try_remove(&audio_spk_fifo, &spk_pb)) {
+            if (audio_spk_fifo.try_remove(&spk_pb)) {
                 memcpy(pkt + 142 + SPEAKER_OPUS_SIZE, spk_pb.data,SPEAKER_OPUS_SIZE);
             } else {
                 printf("[Audio] Warning: Speaker queue remove failed\n");
@@ -170,10 +202,26 @@ void __not_in_flash_func(audio_bt_task)() {
         }
     }
 #endif
+#if defined(DS5_AUDIO_STATS)
+    ++stat_bt_pkts;
+    if (pkt[141] == SPEAKER_OPUS_SIZE) ++stat_bt_with_audio;
+#endif
     bt_write(pkt, sizeof(pkt));
 }
 
-void __not_in_flash_func(audio_loop)() {
+void PORT_FAST_FUNC(audio_loop)() {
+#if defined(DS5_AUDIO_STATS)
+    audio_stats_tick();
+#endif
+    // Surface the worker's overrun counter from here, where printf is allowed.
+    static uint32_t reported_spk_overruns = 0;
+    const uint32_t spk_overruns = audio_spk_overrun_count;
+    if (spk_overruns != reported_spk_overruns) {
+        printf("[Audio] audio_spk_fifo overruns: %lu\n",
+               (unsigned long) (spk_overruns - reported_spk_overruns));
+        reported_spk_overruns = spk_overruns;
+    }
+
     const Config_body &cfg = get_config();
     const bool mic_enabled = mic_active && cfg.mic_select != 3;
     const bool speaker_enabled = cfg.speaker_select != 3;
@@ -181,7 +229,7 @@ void __not_in_flash_func(audio_loop)() {
     /* 
     // Mic playback: drain decoded mic PCM into the USB IN endpoint
     static mic_decode_element mic_pb{};
-    if (queue_try_remove(&mic_decode_fifo, &mic_pb)) {
+    if (mic_decode_fifo.try_remove(&mic_pb)) {
         if (mic_enabled) {
             // The controller mic is mono, but the USB descriptor presents a 2-channel
             // mic (matching the real DS5) so Windows doesn't conflict with its cached
@@ -223,7 +271,7 @@ void __not_in_flash_func(audio_loop)() {
         
         while (tx_fifo && tu_fifo_remaining(tx_fifo) >= 192) {
             if (!has_active_frame) {
-                if (queue_try_remove(&mic_decode_fifo, &active_mic_frame)) {
+                if (mic_decode_fifo.try_remove(&active_mic_frame)) {
                     has_active_frame = true;
                     active_frame_offset = 0;
                 } else {
@@ -273,6 +321,9 @@ void __not_in_flash_func(audio_loop)() {
 
     int16_t raw[192];
     uint32_t bytes_read = tud_audio_read(raw, sizeof(raw)); // 每次读入 384 bytes
+#if defined(DS5_AUDIO_STATS)
+    stat_usb_bytes += bytes_read;
+#endif
     int frames = bytes_read / (INPUT_CHANNELS * sizeof(int16_t));
     if (frames == 0) {
         return;
@@ -288,7 +339,7 @@ void __not_in_flash_func(audio_loop)() {
 #if !DISABLE_SPEAKER_PROC
     if (!speaker_enabled) {
         audio_buf_pos = 0;
-        while (queue_try_remove(&audio_fifo, NULL)) {
+        while (audio_fifo.try_remove(NULL)) {
         }
     }
 #endif
@@ -300,10 +351,13 @@ void __not_in_flash_func(audio_loop)() {
             if (audio_buf_pos == 512 * 2) {
                 static audio_raw_element element{};
                 memcpy(element.data, audio_buf, 512 * 2 * 4);
-                if (queue_is_full(&audio_fifo)) {
-                    queue_try_remove(&audio_fifo, NULL);
+                if (audio_fifo.is_full()) {
+                    audio_fifo.try_remove(NULL);
                 }
-                if (!queue_try_add(&audio_fifo, &element)) {
+                if (!audio_fifo.try_add(&element)) {
+#if defined(DS5_AUDIO_STATS)
+                    ++stat_fifo_drop;
+#endif
                     printf("[Audio] Warning: audio_fifo add failed\n");
                 }
                 audio_buf_pos = 0;
@@ -334,10 +388,10 @@ void __not_in_flash_func(audio_loop)() {
         }
         static haptics_element element{};
         memcpy(element.data, haptic_buf,SAMPLE_SIZE);
-        if (queue_is_full(&haptics_fifo)) {
-            queue_try_remove(&haptics_fifo, NULL);
+        if (haptics_fifo.is_full()) {
+            haptics_fifo.try_remove(NULL);
         }
-        if (!queue_try_add(&haptics_fifo, &element)) {
+        if (!haptics_fifo.try_add(&element)) {
             printf("[Audio] Warning: haptics_fifo add failed\n");
         }
         haptic_buf_pos = 0;
@@ -358,7 +412,7 @@ void audio_init() {
     resampler.SetRates(48000, 3000);
     resampler.SetFeedMode(true);
     resampler.Prealloc(2, 48, 4);
-    queue_init(&haptics_fifo, sizeof(haptics_element), 2);
+    haptics_fifo.init(sizeof(haptics_element), 2);
     // Mic queues are read from audio_loop on core0 every iteration, so they
     // must exist regardless of the speaker-proc build flag.
     //
@@ -366,19 +420,19 @@ void audio_init() {
     // Increased microphone queues to depth 8 (~80ms buffer size).
     // This absorbs initial Opus encoder/decoder warm-up delays and mitigates
     // startup crackling/stuttering under Core 1 task schedulers.
-    // queue_init(&mic_fifo, sizeof(mic_element), 2);
-    // queue_init(&mic_decode_fifo, sizeof(mic_decode_element), 2);
-    queue_init(&mic_fifo, sizeof(mic_element), 8);
-    queue_init(&mic_decode_fifo, sizeof(mic_decode_element), 8);
+    // mic_fifo.init(sizeof(mic_element), 2);
+    // mic_decode_fifo.init(sizeof(mic_decode_element), 2);
+    mic_fifo.init(sizeof(mic_element), 8);
+    mic_decode_fifo.init(sizeof(mic_decode_element), 8);
 #if !DISABLE_SPEAKER_PROC
-    queue_init(&audio_fifo, sizeof(audio_raw_element), 2);
-    queue_init(&audio_spk_fifo, sizeof(audio_spk_element), 2);
+    audio_fifo.init(sizeof(audio_raw_element), 2);
+    audio_spk_fifo.init(sizeof(audio_spk_element), 2);
 #if ENABLE_DEBUG
     // 通常 stack 最大使用 25836 bytes 即 stack[6459]
     debug_fill_core1_stack_watermark(audio_core1_stack,
                                      sizeof(audio_core1_stack) / sizeof(audio_core1_stack[0]));
 #endif
-    multicore_launch_core1_with_stack(core1_entry, audio_core1_stack, sizeof(audio_core1_stack));
+    port::launch_worker(core1_entry, audio_core1_stack, sizeof(audio_core1_stack));
 #endif
 }
 
@@ -389,9 +443,9 @@ static WDL_Resampler resampler_audio;
 // Speaker path: USB OUT PCM (core0 audio_fifo) -> resample -> opus encode ->
 // opus_buf for the haptics/speaker BT report. Non-blocking so core1 can also
 // service the mic path. Kept in RAM to remove XIP miss latency from the loop.
-static void __not_in_flash_func(speaker_proc)() {
+static void PORT_FAST_FUNC(speaker_proc)() {
     static audio_raw_element audio_element{};
-    if (!queue_try_remove(&audio_fifo, &audio_element)) {
+    if (!audio_fifo.try_remove(&audio_element)) {
         return;
     }
     if (get_config().speaker_select == 3) {
@@ -420,19 +474,31 @@ static void __not_in_flash_func(speaker_proc)() {
     if (encoded_len < (int) sizeof(spk_ele.data)) {
         memset(spk_ele.data + encoded_len, 0, sizeof(spk_ele.data) - encoded_len);
     }
-    if (queue_is_full(&audio_spk_fifo)) {
-        queue_try_remove(&audio_spk_fifo, NULL);
-    }
-    if (!queue_try_add(&audio_spk_fifo, &spk_ele)) {
-        printf("[Audio] Warning: audio_spk_fifo add failed\n");
+    // Deliberately NOT dropping the oldest here. Doing so would make this a
+    // second consumer of audio_spk_fifo, racing audio_bt_task()'s paired
+    // removes on the other core: its level() >= 2 check would pass, then this
+    // drop would steal one, and the second remove would fail and ship a zeroed
+    // Opus frame -- a click. Overflow now drops the newest frame instead, which
+    // only happens when the pipeline is already behind.
+#if defined(DS5_AUDIO_STATS)
+    ++stat_opus_frames;
+#endif
+    if (!audio_spk_fifo.try_add(&spk_ele)) {
+        // Counted, not printed. This runs on the audio worker, whose whole
+        // contract is that it never blocks -- and the console is a blocking
+        // UART behind a mutex the main task holds constantly, so a line here
+        // costs milliseconds of a 10 ms frame budget at precisely the moment
+        // the FIFO is already overflowing. Printing would deepen the overrun
+        // it is reporting. audio_loop() reports the delta from the main task.
+        ++audio_spk_overrun_count;
     }
 }
 
 // Mic path: opus packets from the controller (core0 mic_fifo) -> opus decode ->
 // PCM into mic_decode_fifo for audio_loop to push to the USB IN endpoint.
-static void __not_in_flash_func(mic_proc)() {
+static void PORT_FAST_FUNC(mic_proc)() {
     static mic_element mic_packet{};
-    if (!queue_try_remove(&mic_fifo, &mic_packet)) {
+    if (!mic_fifo.try_remove(&mic_packet)) {
         return;
     }
     if (!mic_active || get_config().mic_select == 3) {
@@ -450,24 +516,24 @@ static void __not_in_flash_func(mic_proc)() {
         return;
     }
     decode_element.len = decoded_samples * MIC_CHANNELS * sizeof(int16_t);
-    if (queue_is_full(&mic_decode_fifo)) {
-        queue_try_remove(&mic_decode_fifo, NULL);
+    if (mic_decode_fifo.is_full()) {
+        mic_decode_fifo.try_remove(NULL);
     }
-    queue_try_add(&mic_decode_fifo, &decode_element);
+    mic_decode_fifo.try_add(&decode_element);
 }
 
-void __not_in_flash_func(core1_entry)() {
+void PORT_FAST_FUNC(core1_entry)() {
     // Register core1 as a flash-safe victim so core0's flash_safe_execute() really
     // parks this core while flash is accessed, instead of letting it fault on XIP.
     // Used by config_save() (flash erase/program) and the BOOTSEL poll (which briefly
     // floats QSPI CSn) - the latter makes polling BOOTSEL safe while audio streams on
     // core1. Requires PICO_FLASH_ASSUME_CORE1_SAFE=0.
-    flash_safe_execute_core_init();
+    port::worker_flash_safe_init();
     
     // Allow Core 0 to fully initialize Bluetooth and USB stacks before Core 1 starts processing
     // otherwise the dongle could shut down at initialization
     // TODO: Search for initialization callbacks of core 0
-    sleep_ms(300);
+    port::delay_ms(300);
 
     int error = 0;
     encoder = opus_encoder_create(48000, 2,OPUS_APPLICATION_AUDIO, &error);
@@ -494,11 +560,11 @@ void __not_in_flash_func(core1_entry)() {
         // Only enter processing if data is actually waiting.
         // This avoids constantly acquiring queue locks (spinlocks) when idle,
         // which would otherwise thrash the RP2350 system bus and starve Core 0.
-        if (queue_get_level(&audio_fifo) > 0) {
+        if (audio_fifo.level() > 0) {
             speaker_proc();
             work_done = true;
         }
-        if (queue_get_level(&mic_fifo) > 0) {
+        if (mic_fifo.level() > 0) {
             mic_proc();
             work_done = true;
         }
@@ -506,7 +572,7 @@ void __not_in_flash_func(core1_entry)() {
         // If both queues are empty, we can safely sleep.
         // This prevents 100% CPU usage while maintaining sub-millisecond response times.
         if (!work_done) {
-            sleep_us(10); 
+            port::delay_us(10); 
         }
     }
 }
@@ -514,13 +580,13 @@ void __not_in_flash_func(core1_entry)() {
 // data points at the opus mic payload, len is the bytes available there.
 // In RAM (consistent with the BT-receive path) and validates len so a short
 // or malformed report can't over-read past the packet buffer.
-void __not_in_flash_func(mic_add_queue)(uint8_t *data, uint16_t len) {
+void PORT_FAST_FUNC(mic_add_queue)(uint8_t *data, uint16_t len) {
     if (!mic_active || get_config().mic_select == 3) return;
     if (len < MIC_OPUS_SIZE) return;
     static mic_element mic_packet{};
     memcpy(mic_packet.data, data, MIC_OPUS_SIZE);
-    if (queue_is_full(&mic_fifo)) {
-        queue_try_remove(&mic_fifo, NULL);
+    if (mic_fifo.is_full()) {
+        mic_fifo.try_remove(NULL);
     }
-    queue_try_add(&mic_fifo, &mic_packet);
+    mic_fifo.try_add(&mic_packet);
 }

--- a/src/battery_led.cpp
+++ b/src/battery_led.cpp
@@ -2,13 +2,12 @@
 // Low-battery LED indicator. See battery_led.h.
 //
 
+#include "port/port.h"
 #include "battery_led.h"
 
 #include <cstdint>
 
 #include "config.h"
-#include "pico/cyw43_arch.h"
-#include "pico/time.h"
 
 extern uint8_t interrupt_in_data[63];
 
@@ -34,7 +33,7 @@ void battery_led_init(void) {
 }
 
 void battery_led_note_report(void) {
-    last_report_us = time_us_64();
+    last_report_us = port::now_us();
 }
 
 void battery_led_on_disconnect(void) {
@@ -46,11 +45,11 @@ void battery_led_on_disconnect(void) {
     led_state = false;
     last_report_us = 0;
     last_toggle_us = 0;
-    cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
+    port::led_set(false);
 }
 
 void battery_led_tick(void) {
-    const uint64_t now = time_us_64();
+    const uint64_t now = port::now_us();
     if (last_report_us == 0 || (now - last_report_us) >= REPORT_STALE_US) {
         // No fresh data — bt.cpp owns the LED while disconnected. If we
         // were mid-blink when the report went stale, force the LED off
@@ -58,7 +57,7 @@ void battery_led_tick(void) {
         if (blinking) {
             blinking = false;
             led_state = false;
-            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
+            port::led_set(false);
         }
         return;
     }
@@ -74,18 +73,18 @@ void battery_led_tick(void) {
             blinking = true;
             led_state = true;
             last_toggle_us = now;
-            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, true);
+            port::led_set(true);
             return;
         }
         if ((now - last_toggle_us) >= BLINK_PERIOD_US) {
             led_state = !led_state;
             last_toggle_us = now;
-            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_state);
+            port::led_set(led_state);
         }
     } else if (blinking) {
         blinking = false;
         // Battery recovered or now charging — restore steady-state LED per the user
         // preference flag (LED off when disabled, otherwise the bt.cpp connected = on state).
-        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, !get_config().disable_pico_led);
+        port::led_set(!get_config().disable_pico_led);
     }
 }

--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -2,6 +2,8 @@
 // Created by awalol on 2026/3/4.
 //
 
+#include "port/port.h"
+#include "tusb.h"
 #include <cstdio>
 #include <cstring>
 #include "bt.h"
@@ -13,21 +15,21 @@
 #include "btstack_tlv.h"
 #include "gap.h"
 #include "l2cap.h"
-#include "pico/cyw43_arch.h"
 #include "utils.h"
-#include "bsp/board_api.h"
 #include "classic/sdp_server.h"
 #include "config.h"
 #include "status_gpio.h"
 #include "dse.h"
 #include "fake_ds5.h"
 #include "wake.h"
-#include "pico/util/queue.h"
+#if defined(DS5_HCI_DUMP)
+#include "hci_dump.h"
+#include "hci_dump_embedded_stdout.h"
+#endif
 #if ENABLE_BATT_LED
 #include "battery_led.h"
 #endif
 #if PICO_RP2350
-#include "hardware/regs/sio.h"
 #endif
 
 #define MTU_CONTROL 672
@@ -37,15 +39,94 @@ using std::unordered_map;
 using std::vector;
 using std::queue;
 
+
 static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size);
+extern uint8_t reportSeqCounter; // main.cpp; per-link, reset when a link comes up
+#if defined(DS5_FEATURE_TRACE)
+void feature_trace_state_sent();
+#endif
 
 static void l2cap_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size);
 
 static btstack_packet_callback_registration_t hci_event_callback_registration, l2cap_event_callback_registration;
 static bd_addr_t current_device_addr;
+
+#if defined(PORT_PLATFORM_ESP32S31)
+// Last colour the host asked for, so the pulse re-applies it instead of
+// overriding it. Defaults to the firmware colour for the case where the pulse
+// lands before the host has said anything.
+static uint8_t host_led_r = 0xff, host_led_g = 0xd7, host_led_b = 0x00;
+#endif
 static bool device_found = false;
 static bool new_pair = false; // 只有新匹配的设备才用创建channel，自动重连走的是service
 bool bt_inquiring = false;
+
+// Inquiry scheduling, ESP32-S31 only. Inquiry and page scan share one radio
+// and inquiry wins, so a long inquiry starves the page scan a bonded
+// controller's reconnect needs. Espressif's blob lets inquiry dominate where
+// CYW43439 interleaves fairly, hence the single target. Explicit discovery
+// (BOOTSEL click) still runs one long inquiry.
+#if defined(PORT_PLATFORM_ESP32S31)
+#define BT_INQUIRY_BURSTS 1
+#else
+#define BT_INQUIRY_BURSTS 0
+#endif
+
+
+#if BT_INQUIRY_BURSTS
+// Burst length, not duty cycle, bounds how long a page train can go unheard,
+// so interleaving faster beats holding a quiet window at boot. Not cut below
+// two units: an inquiry must stay open long enough to collect responses, which
+// arrive after a random backoff.
+static constexpr uint8_t kInquiryBurstUnits = 2;      // x1.28s = 2.56s of inquiry
+static constexpr uint32_t kInquiryGapMs = 1500;       // page-scan-only between bursts
+static constexpr uint32_t kInquiryWindowMs = 45000;   // stop looking after this
+
+static uint32_t inquiry_next_at_ms = 0;   // 0 = nothing scheduled
+static uint32_t inquiry_window_end_ms = 0;
+
+static bool use_inquiry_bursts = false;
+
+// Set from the moment a connection is accepted or paged until Connection
+// Complete resolves it. acl_handle alone is not enough -- it stays invalid for
+// the whole of link setup, so the scheduler would start a burst mid-setup and
+// compete with the link it just agreed to bring up.
+static bool connection_pending = false;
+
+// Whether connection_pending came from a page we accepted rather than one we
+// sent. A device that just paged us plainly does not need discovering.
+static bool connection_pending_incoming = false;
+
+static void bt_schedule_inquiry(uint32_t delay_ms) {
+    inquiry_next_at_ms = port::now_ms() + delay_ms;
+    if (inquiry_next_at_ms == 0) inquiry_next_at_ms = 1; // 0 means "not scheduled"
+}
+
+// Bursting only earns its keep when a bonded controller might page us. With no
+// stored pairing there is nothing to reconnect, and yielding inquiry time makes
+// first-time PS+Share pairing slower and flakier.
+static bool bt_has_stored_link_key() {
+    btstack_link_key_iterator_t it;
+    if (!gap_link_key_iterator_init(&it)) return false;
+    bd_addr_t addr;
+    link_key_t key;
+    link_key_type_t type;
+    const bool any = gap_link_key_iterator_get_next(&it, addr, key, &type);
+    gap_link_key_iterator_done(&it);
+    return any;
+}
+#endif
+
+#if defined(PORT_PLATFORM_ESP32S31)
+// One-shot "release the lights" pulse after connect. The DualSense holds its
+// LEDs until the host pulses ResetLights (src/utils.h bit 1.3), and the pulse
+// is ignored during the connect animation -- hence the delay, since the init
+// report goes out ~2ms after the channel opens.
+static constexpr uint32_t kReleaseLightsDelayMs = 3000;
+static constexpr uint32_t kReleaseLightsPaintMs = 120; // gap between pulse and paint
+static uint32_t release_lights_at_ms = 0;
+static uint8_t release_lights_stage = 0;
+#endif
 
 // LED triple-flash confirmation state for clear-all action
 static int bt_clear_flash_toggles_remaining = 0;
@@ -71,14 +152,30 @@ static uint16_t hid_interrupt_cid;
 static bt_data_callback_t bt_data_callback = nullptr;
 static int8_t bt_rssi = 0;
 unordered_map<uint8_t, vector<uint8_t> > feature_data;
-queue_t send_fifo;
+port::Queue send_fifo;
+
+// Control-channel sends are queued: l2cap_send() fails with
+// BTSTACK_ACL_BUFFERS_FULL when no ACL buffer is free, and init_feature()
+// fires four back to back. ESP32-S31 has fewer ACL buffers than CYW43439.
+#if defined(PORT_PLATFORM_ESP32S31)
+port::Queue control_send_fifo;
+#endif
 
 struct send_element {
     uint8_t data[672];
     size_t len;
 };
 
-absolute_time_t inactive_time = 0; // 手柄长时间静默
+// Set when hci_create_connection is refused because no command credit is
+// available, and retried as soon as one comes back. See the INQUIRY_COMPLETE
+// handler for why that happens.
+static bool pending_connect = false;
+
+// Do not request authentication the instant the ACL comes up. BlueRetro waits
+// first, and only for PlayStation controllers; Bluepad32 never sends
+// hci_authentication_requested at all.
+
+uint64_t inactive_time = 0; // 手柄长时间静默 (microseconds since boot)
 
 const uint8_t state_init_data[66] = {
     0xa2, 0x31, 0x01,
@@ -135,6 +232,34 @@ void bt_get_signal_strength(int8_t *rssi) {
     }
 }
 
+// Queue a control-channel packet, draining via L2CAP_EVENT_CAN_SEND_NOW rather
+// than assuming the controller has a buffer free right now.
+static void control_send(const uint8_t *data, const uint16_t len) {
+    if (hid_control_cid == 0) return;
+#if !defined(PORT_PLATFORM_ESP32S31)
+    // RP2350 sends directly. Deferring these broke it: the 0x20 reply drives
+    // the only caller of tud_connect(), so the gamepad paired and the USB
+    // device never appeared.
+    l2cap_send(hid_control_cid, const_cast<uint8_t *>(data), len);
+    return;
+#else
+    static send_element packet{};
+    if (len > sizeof(packet.data)) {
+        printf("[L2CAP] control packet too large: %u\n", (unsigned) len);
+        return;
+    }
+    packet.len = len;
+    memcpy(packet.data, data, len);
+    if (!control_send_fifo.try_add(&packet)) {
+        printf("[L2CAP] Control send FIFO full, dropping packet\n");
+        return;
+    }
+    if (control_send_fifo.level() == 1) {
+        l2cap_request_can_send_now_event(hid_control_cid);
+    }
+#endif
+}
+
 void bt_l2cap_init() {
     l2cap_event_callback_registration.callback = &l2cap_packet_handler;
     l2cap_add_event_handler(&l2cap_event_callback_registration);
@@ -147,17 +272,24 @@ void bt_l2cap_init() {
 }
 
 int bt_init() {
-    queue_init(&send_fifo, sizeof(send_element), 10);
+    send_fifo.init(sizeof(send_element), 10);
+#if defined(PORT_PLATFORM_ESP32S31)
+    control_send_fifo.init(sizeof(send_element), 6);
+#endif
 
     bt_l2cap_init();
 
     // SSP (Secure Simple Pairing)
     gap_ssp_set_enable(true);
+    // Stays ON for both targets: disabling it was tried as a reconnect
+    // workaround and retested in isolation, with no benefit.
     gap_secure_connections_enable(true);
     gap_ssp_set_io_capability(SSP_IO_CAPABILITY_DISPLAY_YES_NO);
     gap_ssp_set_authentication_requirement(SSP_IO_AUTHREQ_MITM_PROTECTION_NOT_REQUIRED_GENERAL_BONDING);
 
     gap_connectable_control(1);
+    // Stays ON: disabling it on ESP32-S31 broke lightbar handover after a
+    // power-cycle and did nothing for reconnect.
     gap_discoverable_control(1);
 
     hci_event_callback_registration.callback = &hci_packet_handler;
@@ -171,14 +303,14 @@ int bt_init() {
     stdio_init_all();
 
     /*while (!stdio_usb_connected()) {
-        sleep_ms(100);
+        port::delay_ms(100);
     }
     printf("USB Serial connected!\n");#1#
 
     bt_init();
 
     while (1) {
-        sleep_ms(10);
+        port::delay_ms(10);
     }
 }*/
 
@@ -265,7 +397,7 @@ static void bt_blacklist_remove(bd_addr_t addr) {
             printf("[BLACKLIST] Removed %s on successful pair, %d remaining (persist deferred)\n",
                    bd_addr_to_str(addr), bt_cleared_addrs_count);
             bt_blacklist_dirty = true;
-            bt_blacklist_dirty_ms = to_ms_since_boot(get_absolute_time());
+            bt_blacklist_dirty_ms = port::now_ms();
             return;
         }
     }
@@ -278,7 +410,7 @@ static void bt_blacklist_remove(bd_addr_t addr) {
 // initial HID/audio state right after pair completion.
 void bt_blacklist_persist_if_dirty() {
     if (!bt_blacklist_dirty) return;
-    uint32_t now = to_ms_since_boot(get_absolute_time());
+    uint32_t now = port::now_ms();
     if (now - bt_blacklist_dirty_ms < 5000) return;
     bt_blacklist_dirty = false;
     printf("[BLACKLIST] Settle window elapsed, persisting deferred change\n");
@@ -336,17 +468,29 @@ void bt_bootsel_hold_action() {
            bt_cleared_addrs_count);
 
     bt_clear_flash_toggles_remaining = 12;
-    bt_clear_flash_last_toggle_ms = to_ms_since_boot(get_absolute_time());
+    bt_clear_flash_last_toggle_ms = port::now_ms();
+}
+
+void bt_note_host_led(uint8_t r, uint8_t g, uint8_t b) {
+#if defined(PORT_PLATFORM_ESP32S31)
+    host_led_r = r;
+    host_led_g = g;
+    host_led_b = b;
+#else
+    // RP2350 hands the lightbar over unprompted, so nothing needs the colour
+    // remembered. A no-op here keeps the call site in main.cpp unguarded.
+    (void) r; (void) g; (void) b;
+#endif
 }
 
 void bt_inquiring_led() {
     // BOOTSEL clear-confirmation triple-flash takes priority over inquiry blink
     if (bt_clear_flash_toggles_remaining > 0) {
-        uint32_t now = to_ms_since_boot(get_absolute_time());
+        uint32_t now = port::now_ms();
         if (now - bt_clear_flash_last_toggle_ms >= 100) {
             bt_clear_flash_last_toggle_ms = now;
             bt_clear_flash_toggles_remaining--;
-            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, (bt_clear_flash_toggles_remaining % 2) == 1);
+            port::led_set((bt_clear_flash_toggles_remaining % 2) == 1);
         }
         return;
     }
@@ -357,19 +501,112 @@ void bt_inquiring_led() {
     static bool led_status = false;
     if (!bt_inquiring) {
         if (led_status) {
-            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
+            port::led_set(false);
         }
         return;
     }
-    static auto last_time = time_us_32();
-    if (time_us_32() - last_time > 200 * 1000) {
-        last_time = time_us_32();
+    static auto last_time = port::now_us32();
+    if (port::now_us32() - last_time > 200 * 1000) {
+        last_time = port::now_us32();
         led_status = !led_status;
-        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_status);
+        port::led_set(led_status);
     }
 }
 
-static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_t channel, uint8_t *packet,
+// hci_send_cmd() does NOT queue: if hci_can_send_command_packet_now() is false
+// it logs and returns ERROR_CODE_COMMAND_DISALLOWED, dropping the command
+// entirely. Callers therefore have to handle refusal themselves.
+static bool bt_try_create_connection() {
+    if (!hci_can_send_command_packet_now()) return false;
+#if BT_INQUIRY_BURSTS
+    connection_pending = true;
+    connection_pending_incoming = false;
+    inquiry_next_at_ms = 0;
+#endif
+    const uint8_t rc = hci_send_cmd(&hci_create_connection, current_device_addr,
+                                    hci_usable_acl_packet_types(), 0, 0, 0, 1);
+    return rc == ERROR_CODE_SUCCESS;
+}
+
+// Retry work that could not be issued from an event handler. Called from the
+// main loop, where BTstack has finished processing whatever it was doing and
+// the command credit is actually available again -- retrying from inside the
+// CommandComplete handler is too early, as the credit is restored after app
+// callbacks have run.
+void bt_task() {
+#if defined(PORT_PLATFORM_ESP32S31)
+    // Two steps, because one report cannot do both jobs. Carrying ResetLights
+    // and a colour together released the LEDs and left them dark: the controller
+    // takes the handover and does not apply a colour from the same report, which
+    // is why the lightbar blanked until the host next sent something. SDL pulses
+    // the bit alone, then paints, so do that.
+    if (release_lights_at_ms != 0 && port::now_ms() >= release_lights_at_ms) {
+        if (hid_interrupt_cid == 0) {
+            release_lights_at_ms = 0;
+            release_lights_stage = 0;
+        } else if (release_lights_stage == 0) {
+            // Step 1: hand the LEDs over. No colour -- AllowLedColor stays 0.
+            SetStateData state = {
+                .AllowAudioControl = 1,
+                .ResetLights = 1,
+                .MicSelect = get_config().mic_select,
+            };
+            update_state(state);
+            release_lights_stage = 1;
+            release_lights_at_ms = port::now_ms() + kReleaseLightsPaintMs;
+            if (release_lights_at_ms == 0) release_lights_at_ms = 1;
+        } else {
+            // Step 2: paint whatever the host last asked for. In the paths that
+            // already worked this repaints the value already showing, so it is
+            // invisible there.
+            SetStateData state = {
+                .AllowAudioControl = 1,
+                .AllowLedColor = 1,
+                .MicSelect = get_config().mic_select,
+                .AllowLightBrightnessChange = 1,
+                .AllowColorLightFadeAnimation = 1,
+                .LightFadeAnimation = LightFadeAnimation::FadeOut,
+                .LightBrightness = LightBrightness::Bright,
+                .LedRed = host_led_r,
+                .LedGreen = host_led_g,
+                .LedBlue = host_led_b,
+            };
+            update_state(state);
+            printf("[%lu] [LED] lights released, painted %02X%02X%02X\n",
+                   (unsigned long) port::now_ms(), host_led_r, host_led_g, host_led_b);
+            release_lights_at_ms = 0;
+            release_lights_stage = 0;
+        }
+    }
+#endif
+#if BT_INQUIRY_BURSTS
+    if (inquiry_next_at_ms != 0 && port::now_ms() >= inquiry_next_at_ms) {
+        inquiry_next_at_ms = 0;
+        // Never inquire over a live link -- that is what made the report rate
+        // collapse on reconnect, and it is why the connection-request handler
+        // calls gap_inquiry_stop().
+        if (acl_handle == HCI_CON_HANDLE_INVALID && !connection_pending && !bt_inquiring) {
+            // gap_inquiry_start() returns ERROR_CODE_COMMAND_DISALLOWED when
+            // no command credit is available; a burst schedule that loses one
+            // start would stop looking entirely.
+            if (gap_inquiry_start(kInquiryBurstUnits) == ERROR_CODE_SUCCESS) {
+                bt_inquiring = true;
+            } else {
+                bt_schedule_inquiry(250);
+            }
+        }
+    }
+#endif
+
+    if (!pending_connect) return;
+    if (bt_try_create_connection()) {
+        printf("[HCI] Deferred connect sent\n");
+        pending_connect = false;
+    }
+}
+
+
+static void PORT_FAST_FUNC(hci_packet_handler)(uint8_t packet_type, uint16_t channel, uint8_t *packet,
                                                     uint16_t size) {
     (void) channel;
 
@@ -380,12 +617,35 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             const uint8_t state = btstack_event_state_get_state(packet);
             printf("[BT] State: %u\n", state);
             if (state == HCI_STATE_WORKING) {
+#if defined(PORT_PLATFORM_ESP32S31)
+                // interval 50ms, window 11.25ms. Core Spec 5.4 Vol 2 Part B
+                // 8.3.1 requires interval >= 2x window for interlaced scan.
+                // Neither HCI command validates the pair, so equal values
+                // return success and misconfigure the controller -- and leave
+                // no slots for a forming link's LMP exchanges.
+                gap_set_page_scan_activity(0x0050, 0x0012);
+#else
                 gap_set_page_scan_activity(0x0012, 0x0012); // 11.25ms
+#endif
                 gap_set_page_scan_type(PAGE_SCAN_MODE_INTERLACED);
+#if BT_INQUIRY_BURSTS
+                bt_blacklist_load();
+                use_inquiry_bursts = bt_has_stored_link_key();
+                if (use_inquiry_bursts) {
+                    printf("[BT] Stack ready, interleaving inquiry with page scan\n");
+                    inquiry_window_end_ms = port::now_ms() + kInquiryWindowMs;
+                    bt_schedule_inquiry(0); // first burst immediately; gaps follow
+                } else {
+                    printf("[BT] Stack ready, no pairing stored, start inquiry\n");
+                    gap_inquiry_start(30);
+                    bt_inquiring = true;
+                }
+#else
                 printf("[BT] Stack ready, start inquiry\n");
                 bt_blacklist_load();
                 gap_inquiry_start(30);
                 bt_inquiring = true;
+#endif
             }
             break;
         }
@@ -425,21 +685,37 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             if (device_found) {
                 printf("[HCI] Connecting to %s...\n", bd_addr_to_str(current_device_addr));
                 new_pair = true;
-                hci_send_cmd(&hci_create_connection, current_device_addr,
-                             hci_usable_acl_packet_types(), 0, 0, 0, 1);
+                // gap_inquiry_stop() above sent HCI_INQUIRY_CANCEL, and BTstack
+                // raises GAP_EVENT_INQUIRY_COMPLETE while that command is still
+                // outstanding -- so there is often no command credit left here
+                // and the connect would be silently discarded. Retry when a
+                // credit returns.
+                if (!bt_try_create_connection()) {
+                    printf("[HCI] Connect deferred (no command credit)\n");
+                    pending_connect = true;
+                }
                 break;
             }
             if (event_type == HCI_EVENT_INQUIRY_COMPLETE) {
-                // gap_inquiry_start(30);
                 gap_connectable_control(1);
                 gap_discoverable_control(1);
+#if BT_INQUIRY_BURSTS
+                // Another burst after a quiet gap, until the window expires.
+                // Upstream stops inquiring entirely here; keeping it going in
+                // bursts costs nothing now that page scan gets the gaps.
+                if (use_inquiry_bursts && acl_handle == HCI_CON_HANDLE_INVALID &&
+                    port::now_ms() < inquiry_window_end_ms) {
+                    bt_schedule_inquiry(kInquiryGapMs);
+                }
+#endif
             }
             break;
         }
         case HCI_EVENT_COMMAND_STATUS: {
             const uint8_t status = hci_event_command_status_get_status(packet);
             const uint16_t opcode = hci_event_command_status_get_command_opcode(packet);
-            printf("[HCI] CmdStatus %s(0x%04X) status=0x%02X\n", opcode_to_str(opcode), opcode, status);
+            printf("[%lu] [HCI] CmdStatus %s(0x%04X) status=0x%02X\n",
+                   (unsigned long) port::now_ms(), opcode_to_str(opcode), opcode, status);
             if (opcode == HCI_OPCODE_HCI_CREATE_CONNECTION && status != ERROR_CODE_SUCCESS) {
                 device_found = false;
                 new_pair = false;
@@ -467,6 +743,12 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
         }
 
         case HCI_EVENT_CONNECTION_COMPLETE: {
+            // Whatever the outcome, the attempt is over -- do not let a stale
+            // deferred connect fire again on the next command credit.
+            pending_connect = false;
+#if BT_INQUIRY_BURSTS
+            connection_pending = false;
+#endif
             const uint8_t status = hci_event_connection_complete_get_status(packet);
             if (status == 0) {
                 const hci_con_handle_t handle = hci_event_connection_complete_get_connection_handle(packet);
@@ -477,12 +759,10 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
                 // CONNECTION_REQUEST-time reject is racing with hci_run() and
                 // doesn't reliably block. Catch the connection here, after it
                 // has completed but before we set up any state or request auth,
-                // and disconnect immediately with auth-failure reason.
-                //
-                // Only block INCOMING connections (controller PAGE'd us, e.g. PS-only
-                // auto-reconnect). Outgoing connections that we initiated via inquiry
-                // (PS+Share user-explicit re-pair) have new_pair == true and are
-                // allowed through so the blacklist entry can be removed at HID open.
+                // and disconnect immediately with auth-failure reason. Only
+                // INCOMING connections are blocked; an outgoing one we initiated
+                // has new_pair == true and is allowed through so the blacklist
+                // entry can be cleared at HID open.
                 if (!new_pair && bt_blacklist_contains(conn_addr)) {
                     printf("[HCI] Incoming connection from blacklisted %s on handle=0x%04X - disconnecting\n",
                            bd_addr_to_str(conn_addr), handle);
@@ -492,15 +772,65 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
 
                 acl_handle = handle;
                 bt_rssi = 0;
+#if BT_INQUIRY_BURSTS
+                inquiry_next_at_ms = 0; // do not inquire over a live link
+#endif
                 bd_addr_copy(current_device_addr, conn_addr);
                 printf("[HCI] ACL connected handle=0x%04X\n", handle);
+#if defined(DS5_HCI_DUMP)
+                // Diagnostic build only. Enabled here rather than at startup so
+                // the trace begins at the interesting part -- SSP and the L2CAP
+                // signalling -- instead of burying it under boot and inquiry.
+                hci_dump_init(hci_dump_embedded_stdout_get_instance());
+#endif
                 printf("[HCI] Request authentication on handle=0x%04X\n", handle);
                 hci_send_cmd(&hci_authentication_requested, handle);
             } else {
                 device_found = false;
                 new_pair = false;
-                printf("[HCI] ACL connect failed status=0x%02X\n", status);
-                // gap_inquiry_start(30);
+                bd_addr_t fail_addr;
+                hci_event_connection_complete_get_bd_addr(packet, fail_addr);
+                printf("[%lu] [HCI] ACL connect failed status=0x%02X addr=%s\n",
+                       (unsigned long) port::now_ms(), status, bd_addr_to_str(fail_addr));
+                if (status == 0x0B) {
+                    // ACL Connection Already Exists. Seen after the controller
+                    // asserted mid-pairing: one side still believes a link is
+                    // up. Resetting the controller clears our half; the
+                    // DualSense may need its own reset button.
+                    printf("[HCI] (link already exists -- reset the controller if this repeats)\n");
+                }
+                // Go back to inquiry instead of sitting idle. Without this a
+                // single failed connect leaves the dongle dead until a power
+                // cycle, which is what made this look like a hang.
+                device_found = false;
+                new_pair = false;
+#if BT_INQUIRY_BURSTS
+                // The remote paged us and the attempt failed, so it is nearby
+                // and still trying. Inquiry cannot find something already
+                // knocking, and takes the radio from the page scan that would
+                // hear the next knock.
+                if (connection_pending_incoming) {
+                    connection_pending_incoming = false;
+                    printf("[HCI] Incoming attempt failed; page scanning rather than inquiring\n");
+                    break;
+                }
+                // Re-evaluate rather than latching at boot: the first pairing
+                // of a session stores a key, and a dongle that booted with an
+                // empty store must switch to bursting once something can page
+                // it. Latching meant a failed reconnect restarted a 38s
+                // continuous inquiry.
+                use_inquiry_bursts = bt_has_stored_link_key();
+                if (use_inquiry_bursts) {
+                    inquiry_window_end_ms = port::now_ms() + kInquiryWindowMs;
+                    bt_schedule_inquiry(kInquiryGapMs);
+                } else {
+                    gap_inquiry_start(30);
+                    bt_inquiring = true;
+                }
+#else
+                gap_inquiry_start(30);
+                bt_inquiring = true;
+#endif
             }
             break;
         }
@@ -511,17 +841,34 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             link_key_t link_key;
             link_key_type_t link_key_type;
             bool link = gap_get_link_key_for_bd_addr(addr, link_key, &link_key_type);
-            printf("[HCI] Link key: ");
-            for (int i = 0; i < sizeof(link_key_t); i++) {
-                printf("%02X", link_key[i]);
+            if (link) {
+                printf("[HCI] Link key: ");
+                for (int i = 0; i < sizeof(link_key_t); i++) {
+                    printf("%02X", link_key[i]);
+                }
+                printf("\n");
             }
-            printf("\n");
             if (link) {
                 printf("[HCI] Link key request from %s, reply stored key type=%u\n", bd_addr_to_str(addr),
                        (unsigned int) link_key_type);
+#if defined(PORT_PLATFORM_ESP32S31)
+                // As in the no-key branch below: BTstack answers link key
+                // requests itself (hci.c, AUTH_FLAG_HANDLE_LINK_KEY_REQUEST),
+                // reading the same TLV database this printf just read, so the
+                // key is identical and ours is purely a duplicate. Unreached
+                // until a pairing survives, but it is the same hazard.
+                break;
+#endif
                 hci_send_cmd(&hci_link_key_request_reply, addr, link_key);
             } else {
                 printf("[HCI] Link key request from %s, no key, force re-pair\n", bd_addr_to_str(addr));
+#if defined(PORT_PLATFORM_ESP32S31)
+                // Deliberately do NOT reply: BTstack already sends the negative
+                // reply (hci.c, hci_link_key_request_negative_reply). Replying
+                // again puts two responses on the wire for one request, the
+                // second rejected with 0x0C Command Disallowed.
+                break;
+#endif
                 hci_send_cmd(&hci_link_key_request_negative_reply, addr);
             }
             break;
@@ -530,7 +877,16 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
         case HCI_EVENT_USER_CONFIRMATION_REQUEST: {
             bd_addr_t addr;
             hci_event_user_confirmation_request_get_bd_addr(packet, addr);
-            printf("[HCI] User confirmation request from %s, accept\n", bd_addr_to_str(addr));
+            printf("[%lu] [HCI] User confirmation request from %s, accept\n",
+                   (unsigned long) port::now_ms(), bd_addr_to_str(addr));
+#if defined(PORT_PLATFORM_ESP32S31)
+            // Same duplicate-response hazard as the link key request above, and
+            // the one that crashed the controller (assert in olm_lmp_ssp.c:1820).
+            // BTstack auto-accepts user confirmation (hci_stack->ssp_auto_accept)
+            // and replies from hci_run(); ours put a second reply on the wire,
+            // arriving after the SSP state machine had moved on.
+            break;
+#endif
             hci_send_cmd(&hci_user_confirmation_request_reply, addr);
             break;
         }
@@ -552,11 +908,25 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
                 gap_drop_link_key_for_bd_addr(current_device_addr);
                 // gap_inquiry_start(30);
             } else {
+#if defined(PORT_PLATFORM_ESP32S31)
+                // BTstack requests encryption itself from hci_run() once
+                // authentication completes (BONDING_SEND_ENCRYPTION_REQUEST), so
+                // ours is a duplicate -- observed on the wire 1ms later, answered
+                // 0x0C Command Disallowed.
+                (void) handle;
+#else
                 hci_send_cmd(&hci_set_connection_encryption, handle, 1);
+#endif
             }
             break;
         }
 
+        // 0x59 is the Bluetooth 5.4 v2 form of this event, which adds a key
+        // size field. The ESP32-S31 controller emits ONLY v2; CYW43439 on the
+        // Pico emits only v1, so matching just v1 silently skipped this whole
+        // branch on ESP32 and we never opened the HID channels. The first three
+        // fields are identical in both, so the v1 getters read v2 correctly.
+        case HCI_EVENT_ENCRYPTION_CHANGE_V2:
         case HCI_EVENT_ENCRYPTION_CHANGE: {
             const uint8_t status = hci_event_encryption_change_get_status(packet);
             const hci_con_handle_t handle = hci_event_encryption_change_get_connection_handle(packet);
@@ -591,7 +961,20 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
                 // 这里的 stop 触发条件是：刚开机时，pico 处于 inquiry 模式，然后 DS5 通过 PS 键重连
                 // 如果在连接上以后没有停止 inquiry，会导致回报率很低
                 gap_inquiry_stop();
+#if BT_INQUIRY_BURSTS
+                connection_pending = true;
+                connection_pending_incoming = true;
+                inquiry_next_at_ms = 0; // drop any burst already scheduled
+#endif
+#if defined(PORT_PLATFORM_ESP32S31)
+                // Left to BTstack, which accepts from hci_run() with the same
+                // "remain slave" policy. Accepting here put a second
+                // Accept_Connection_Request ahead of gap_inquiry_stop()'s
+                // deferred Inquiry_Cancel, asking the controller to accept
+                // while still inquiring.
+#else
                 hci_send_cmd(&hci_accept_connection_request, addr, 0x01);
+#endif
             }
             break;
         }
@@ -615,10 +998,18 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
             bt_rssi = 0;
             hid_control_cid = 0;
             hid_interrupt_cid = 0;
+#if defined(PORT_PLATFORM_ESP32S31)
+            release_lights_at_ms = 0;
+            release_lights_stage = 0;
+#endif
             gpio_on_disconnect();
-            while (queue_try_remove(&send_fifo, NULL)) {
+            while (send_fifo.try_remove(NULL)) {
             }
-            cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
+#if defined(PORT_PLATFORM_ESP32S31)
+            while (control_send_fifo.try_remove(NULL)) {
+            }
+#endif
+            port::led_set(false);
 #if ENABLE_BATT_LED
             battery_led_on_disconnect();
 #endif
@@ -639,7 +1030,7 @@ static void __not_in_flash_func(hci_packet_handler)(uint8_t packet_type, uint16_
     }
 }
 
-static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint16_t channel, uint8_t *packet,
+static void PORT_FAST_FUNC(l2cap_packet_handler)(uint8_t packet_type, uint16_t channel, uint8_t *packet,
                                                       uint16_t size) {
     (void) channel;
 
@@ -660,17 +1051,21 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
                 packet[7] > 0 || packet[8] > 0 ||
                 packet[10] != 0x08 || packet[11] != 0x00 ||
                 packet[12] != 0x00) {
-                inactive_time = get_absolute_time();
-            } else if (absolute_time_diff_us(inactive_time, get_absolute_time()) >
+                inactive_time = port::now_us();
+            } else if (static_cast<int64_t>(port::now_us() - inactive_time) >
                        static_cast<int64_t>(get_config().inactive_time) * 60 * 1000 * 1000) {
                 printf("disconnect when inactive\n");
-                inactive_time = get_absolute_time();
+                inactive_time = port::now_us();
                 bt_disconnect();
             }
         } else if (channel == hid_control_cid) {
             if (packet[0] == 0xA3) {
                 const uint8_t report_id = packet[1];
                 feature_data[report_id].assign(packet + 2, packet + size);
+#if defined(DS5_FEATURE_TRACE)
+                printf("[%lu] [FEAT] reply 0x%02X len=%u\n",
+                       (unsigned long) port::now_ms(), report_id, size - 2);
+#endif
 #if ENABLE_VERBOSE
                 printf("[L2CAP] Stored Feature Report 0x%02X, len=%u\n", report_id, size - 2);
                 printf("[L2CAP] HID Control data len=%u\n", size);
@@ -720,9 +1115,12 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
 
                     if (new_pair) {
                         printf("[L2CAP] Opening interrupt channel\n");
-                        l2cap_create_channel(l2cap_packet_handler, current_device_addr, PSM_HID_INTERRUPT,
-                                             MTU_INTERRUPT,
-                                             &hid_interrupt_cid);
+                        const uint8_t rc = l2cap_create_channel(l2cap_packet_handler, current_device_addr,
+                                                                PSM_HID_INTERRUPT, MTU_INTERRUPT,
+                                                                &hid_interrupt_cid);
+                        if (rc != ERROR_CODE_SUCCESS) {
+                            printf("[L2CAP] Interrupt channel create failed rc=0x%02X\n", rc);
+                        }
                     }
                 } else if (psm == PSM_HID_INTERRUPT) {
                     printf("[L2CAP] HID Interrupt opened cid=0x%04X\n", local_cid);
@@ -733,11 +1131,20 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
                     bt_blacklist_remove(current_device_addr);
 
                     if (!get_config().disable_pico_led) {
-                        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, true);
+                        port::led_set(true);
                     }
-                    inactive_time = get_absolute_time();
+                    inactive_time = port::now_us();
 
                     printf("Init DualSense\n");
+
+                    // The output report sequence number is per-LINK. As a plain
+                    // global it kept counting across links, so a second connection
+                    // began mid-sequence and the DualSense rejected it -- which is
+                    // why replugging the dongle (a reboot) worked while a PS-hold
+                    // power-cycle did not.
+#if defined(PORT_PLATFORM_ESP32S31)
+                    reportSeqCounter = 0;
+#endif
 
                     init_feature();
                     SetStateData state = {
@@ -754,6 +1161,20 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
                         .LedBlue = 0x00,
                     };
                     update_state(state);
+#if defined(DS5_FEATURE_TRACE)
+                    feature_trace_state_sent();
+#endif
+
+#if defined(PORT_PLATFORM_ESP32S31)
+                    // Steam never pulses ResetLights (verified: reset=0 on every
+                    // host report), and in wireless mode the DualSense holds its own
+                    // LEDs until that bit is pulsed -- so after a PS-hold power-cycle
+                    // the lightbar stays on the controller's connect blue and ignores
+                    // every colour the host asks for.
+                    release_lights_stage = 0;
+                    release_lights_at_ms = port::now_ms() + kReleaseLightsDelayMs;
+                    if (release_lights_at_ms == 0) release_lights_at_ms = 1;
+#endif
 
                     // Re-arm controller mic streaming for the new link. The 0x32
                     // mic-status packet is otherwise only sent when the host opens
@@ -801,10 +1222,12 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
             const uint16_t local_cid = l2cap_event_channel_closed_get_local_cid(packet);
             if (local_cid == hid_control_cid) {
                 hid_control_cid = 0;
-                printf("[L2CAP] HID Control closed cid=0x%04X\n", local_cid);
+                printf("[%lu] [L2CAP] HID Control closed cid=0x%04X\n",
+                       (unsigned long) port::now_ms(), local_cid);
             } else if (local_cid == hid_interrupt_cid) {
                 hid_interrupt_cid = 0;
-                printf("[L2CAP] HID Interrupt closed cid=0x%04X\n", local_cid);
+                printf("[%lu] [L2CAP] HID Interrupt closed cid=0x%04X\n",
+                       (unsigned long) port::now_ms(), local_cid);
             } else {
                 printf("[L2CAP] Channel closed cid=0x%04X\n", local_cid);
             }
@@ -817,14 +1240,32 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
         case L2CAP_EVENT_CAN_SEND_NOW: {
             // printf("[L2CAP] L2CAP_EVENT_CAN_SEND_NOW\n");
 
+#if defined(PORT_PLATFORM_ESP32S31)
+            // The event names the channel it is for; both channels request it.
+            const uint16_t ready_cid = l2cap_event_can_send_now_get_local_cid(packet);
+            if (ready_cid == hid_control_cid && hid_control_cid != 0) {
+                send_element control_packet{};
+                if (control_send_fifo.try_remove(&control_packet)) {
+                    const uint8_t status = l2cap_send(hid_control_cid, control_packet.data, control_packet.len);
+                    if (status != 0) {
+                        printf("[L2CAP] Control send error, status: 0x%02X\n", status);
+                    }
+                }
+                if (!control_send_fifo.is_empty()) {
+                    l2cap_request_can_send_now_event(hid_control_cid);
+                }
+                break;
+            }
+#endif
+
             send_element send_packet{};
-            if (queue_try_remove(&send_fifo, &send_packet)) {
+            if (send_fifo.try_remove(&send_packet)) {
                 const uint8_t status = l2cap_send(hid_interrupt_cid, send_packet.data, send_packet.len);
                 if (status != 0) {
                     printf("[L2CAP] L2CAP Send Error, Status: 0x%02X\n", status);
                 }
             }
-            if (!queue_is_empty(&send_fifo)) {
+            if (!send_fifo.is_empty()) {
                 l2cap_request_can_send_now_event(hid_interrupt_cid);
             }
             break;
@@ -839,11 +1280,11 @@ uint16_t bt_control_cid() {
 
 void bt_control_send(const uint8_t *data, uint16_t len) {
     if (hid_control_cid != 0) {
-        l2cap_send(hid_control_cid, const_cast<uint8_t *>(data), len);
+        control_send(data, len);
     }
 }
 
-void __not_in_flash_func(bt_write)(const uint8_t *data, const uint16_t len) {
+void PORT_FAST_FUNC(bt_write)(const uint8_t *data, const uint16_t len) {
     if (hid_interrupt_cid == 0) return;
     static send_element packet{};
     packet.len = len + 1;
@@ -851,11 +1292,11 @@ void __not_in_flash_func(bt_write)(const uint8_t *data, const uint16_t len) {
     memcpy(packet.data + 1, data, len);
     fill_output_report_checksum(packet.data + 1, len);
 
-    if (!queue_try_add(&send_fifo, &packet)) {
+    if (!send_fifo.try_add(&packet)) {
         printf("[L2CAP bt_write] Error: Failed to add packet to send FIFO\n");
         return;
     }
-    if (queue_get_level(&send_fifo) == 1) {
+    if (send_fifo.level() == 1) {
         l2cap_request_can_send_now_event(hid_interrupt_cid);
     }
 }
@@ -880,7 +1321,10 @@ vector<uint8_t> get_feature_data(uint8_t reportId, uint16_t len) {
     ) {
         if (hid_control_cid != 0) {
             uint8_t get_feature[] = {0x43, reportId};
-            l2cap_send(hid_control_cid, get_feature, sizeof(get_feature));
+#if defined(DS5_FEATURE_TRACE)
+            printf("[%lu] [FEAT] request 0x%02X\n", (unsigned long) port::now_ms(), reportId);
+#endif
+            control_send(get_feature, sizeof(get_feature));
 #if ENABLE_VERBOSE
             printf("[L2CAP] Requesting Get Feature Report 0x%02X\n", reportId);
 #endif
@@ -896,7 +1340,7 @@ void set_feature_data(uint8_t reportId, uint8_t *data, uint16_t len) {
         get_feature[1] = reportId;
         memcpy(get_feature + 2, data, len);
         fill_feature_report_checksum(get_feature + 1, len + 1);
-        l2cap_send(hid_control_cid, get_feature, len + 2);
+        control_send(get_feature, len + 2);
 #if ENABLE_VERBOSE
         printf("[L2CAP] Requesting Set Feature Report 0x%02X\n", reportId);
         printf_hexdump(get_feature, len + 2);
@@ -904,6 +1348,12 @@ void set_feature_data(uint8_t reportId, uint8_t *data, uint16_t len) {
         dse_on_profile_write(reportId);
     }
 }
+
+#if defined(DS5_FEATURE_TRACE)
+void feature_trace_state_sent() {
+    printf("[%lu] [FEAT] output report sent (lightbar/state)\n", (unsigned long) port::now_ms());
+}
+#endif
 
 void init_feature() {
     feature_data.clear();

--- a/src/bt.h
+++ b/src/bt.h
@@ -27,10 +27,17 @@ void bt_set_scan_idle();
 void bt_set_scan_active();
 void dse_unlock_task();
 bool bt_dse_profiles_ready();
+// Periodic hook; call from the main loop alongside the other *_task()s.
+void bt_task();
+
 void bt_write(const uint8_t *data, uint16_t len);
 void bt_get_signal_strength(int8_t *rssi);
 std::vector<uint8_t> get_feature_data(uint8_t reportId,uint16_t len);
 void init_feature();
+
+// Remember what the host last asked the lightbar to be, so the ResetLights
+// pulse can re-apply that rather than overriding it with the firmware default.
+void bt_note_host_led(uint8_t r, uint8_t g, uint8_t b);
 void set_feature_data(uint8_t reportId, uint8_t* data,uint16_t len);
 void bt_inquiring_led();
 // BOOTSEL button actions, dispatched from button_functions.cpp.

--- a/src/button_functions.cpp
+++ b/src/button_functions.cpp
@@ -2,21 +2,12 @@
 // BOOTSEL button gestures, split out of bt.cpp.
 //
 
+#include "port/port.h"
 #include "button_functions.h"
 
 #include <cstdio>
 
 #include "bt.h"
-#include "pico/time.h"
-#include "pico/flash.h"
-#include "hardware/gpio.h"
-#include "hardware/sync.h"
-#include "hardware/structs/ioqspi.h"
-#include "hardware/structs/sio.h"
-#include "pico/bootrom.h"
-#if PICO_RP2350
-#include "hardware/regs/sio.h"
-#endif
 
 // Gesture thresholds, in samples at the 100 ms (10 Hz) poll cadence.
 static constexpr int HOLD_SAMPLES = 15;         // ~1.5 s held -> clear all pairings
@@ -29,58 +20,25 @@ static int button_wait_samples = 0;
 static int button_click_count = 0;
 static uint32_t button_last_check_ms = 0;
 
-// Read BOOTSEL by briefly floating the QSPI CSn line. Must run with both cores
-// in a known-safe state - if core 1 does an XIP read while CSn is floating it
-// gets garbage and the CYW43 driver misbehaves (immediate BT disconnect on audio
-// start). flash_safe_execute() handles the multicore coordination - the same SDK
-// mechanism BTstack uses for its TLV flash writes.
-static void __no_inline_not_in_flash_func(button_read_cb)(void *param) {
-    bool *out = (bool *) param;
-    const uint CS_PIN_INDEX = 1;
-
-    hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,
-                    GPIO_OVERRIDE_LOW << IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_LSB,
-                    IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_BITS);
-
-    for (volatile int i = 0; i < 1000; ++i);
-
-#if PICO_RP2350
-    *out = !(sio_hw->gpio_hi_in & SIO_GPIO_HI_IN_QSPI_CSN_BITS);
-#else
-    *out = !(sio_hw->gpio_hi_in & (1u << CS_PIN_INDEX));
-#endif
-
-    hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,
-                    GPIO_OVERRIDE_NORMAL << IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_LSB,
-                    IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_BITS);
-}
-
-static bool button_read_bootsel() {
-    bool pressed = false;
-    // 100 ms timeout for the safe-state coordination; the poll is gated on the
-    // 10 Hz cadence and the safe-execute parks core1, so this never runs during
-    // active audio reads anyway.
-    int rc = flash_safe_execute(button_read_cb, &pressed, 100);
-    if (rc != PICO_OK) return false;
-    return pressed;
-}
-
 // Act on a completed click sequence once the inter-click window closes.
 static void button_dispatch(int clicks) {
     if (clicks <= 1) {
         bt_bootsel_click_action(); // single click -> pair / switch controller
     } else if (clicks == 2) {
-        // double click -> normal reboot. A Cortex-M33 SYSRESETREQ does a warm
-        // reset that re-runs the flash app; a watchdog reset instead drops the
-        // RP2350 bootrom into BOOTSEL, which is why watchdog_reboot/enable bricked.
+        // double click -> normal reboot.
         printf("[BTN] BOOTSEL double click - reboot\n");
-        *((volatile uint32_t *) 0xe000ed0c) = 0x05fa0004; // SCB AIRCR: VECTKEY | SYSRESETREQ
-        __dsb();
-        while (true) { tight_loop_contents(); } // wait for the reset
-    } else {
-        // triple click -> reboot into BOOTSEL (USB mass storage) for reflashing.
+        port::reboot(); // noreturn
+    } else if (port::has_bootloader_reboot()) {
+        // triple click -> reboot into the ROM bootloader for reflashing.
         printf("[BTN] BOOTSEL triple click - reboot to BOOTSEL\n");
-        reset_usb_boot(0, 0); // noreturn
+        port::reboot_to_bootloader(); // noreturn
+    } else {
+        // No third gesture on this target: there is no software route to a flash
+        // mode, and the host tool straps the chip into download boot itself. Do
+        // nothing rather than fall through to a reboot, which would make a
+        // mis-counted click drop the controller link.
+        printf("[BTN] BOOTSEL triple click - no flash mode on this target; hold "
+               "BOOT while resetting, or just run the flash tool\n");
     }
 }
 
@@ -90,16 +48,16 @@ static void button_dispatch(int clicks) {
 // Clicks are counted across the inter-click window; the action fires when it closes.
 // Also services the deferred blacklist persist on the same cadence.
 void button_check() {
-    // No connection gate: safe to poll during audio because button_read_bootsel()
+    // No connection gate: safe to poll during audio because port::boot_button_pressed()
     // uses flash_safe_execute(), which parks core1 (the audio core) for the QSPI
     // CSn float -- see flash_safe_execute_core_init() and PICO_FLASH_ASSUME_CORE1_SAFE=0.
-    uint32_t now = to_ms_since_boot(get_absolute_time());
+    uint32_t now = port::now_ms();
     if (now - button_last_check_ms < 100) return;
     button_last_check_ms = now;
 
     bt_blacklist_persist_if_dirty();
 
-    bool pressed = button_read_bootsel();
+    bool pressed = port::boot_button_pressed();
 
     switch (button_fsm) {
         case 0: // IDLE - wait for the first press

--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -2,6 +2,7 @@
 // Created by awalol on 2026/5/4.
 //
 
+#include "port/port.h"
 #include "cmd.h"
 
 #include <algorithm>
@@ -11,7 +12,6 @@
 #include "bt.h"
 #include "config.h"
 #include "device/usbd.h"
-#include "pico/time.h"
 #include "audio.h"
 #include "wake.h"
 
@@ -40,8 +40,8 @@ uint16_t pico_cmd_get(uint8_t report_id, uint8_t *buffer, uint16_t reqlen) {
     }
     if (report_id == 0xf8) {
         printf("[HID] Receive 0xf8 getting firmware version\n");
-        const auto len = std::min(strlen(PICO_PROGRAM_VERSION_STRING), static_cast<size_t>(reqlen));
-        memcpy(buffer, PICO_PROGRAM_VERSION_STRING, len);
+        const auto len = std::min(strlen(DS5_FIRMWARE_VERSION), static_cast<size_t>(reqlen));
+        memcpy(buffer, DS5_FIRMWARE_VERSION, len);
         return len;
     }
     if (report_id == 0xf9) {
@@ -94,7 +94,7 @@ void pico_cmd_set(uint8_t report_id, uint8_t const *buffer, uint16_t bufsize) {
         printf("[CMD] Enter tud reconnect func\n");
         wake_note_usb_reconnect();   // this disconnect is intentional, not a host sleep
         tud_disconnect();
-        sleep_ms(150);
+        port::delay_ms(150);
         tud_connect();
     }
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -10,44 +10,40 @@
 #include "bt.h"
 #include "status_gpio.h"
 #include "utils.h"
-#include "hardware/flash.h"
-#include "hardware/sync.h"
-#include "pico/btstack_flash_bank.h"
-#include "pico/cyw43_arch.h"
-#include "pico/flash.h"
+#include "port/port.h"
 
 constexpr uint32_t CONFIG_MAGIC = 0x66ccff00;
 constexpr uint16_t CONFIG_VERSION = 5; // 如果想要强制重置配置，再更新 CONFIG_VERSION。
-constexpr uint32_t CONFIG_FLASH_OFFSET = PICO_FLASH_BANK_STORAGE_OFFSET - FLASH_SECTOR_SIZE;
 static Config config{};
 bool is_dse = false;
 
 // 编译期保护
 // 判断Config结构体是否能放进flash 256bytes
-static_assert(sizeof(Config) <= FLASH_PAGE_SIZE);
-// 配置区起始地址必须按 flash sector 对齐。
-static_assert(CONFIG_FLASH_OFFSET % FLASH_SECTOR_SIZE == 0);
+static_assert(sizeof(Config) <= port::kConfigStoragePageSize);
 
 static uint32_t calc_config_crc(const Config &con) {
     return crc32(reinterpret_cast<const uint8_t *>(&con.body), sizeof(Config_body));
 }
 
-static const Config *get_xip_addr(uint32_t offset) {
-    return reinterpret_cast<const Config *>(XIP_BASE + offset);
+const Config *flash_config() {
+    return static_cast<const Config *>(port::config_storage_read());
 }
 
+// Migration for upstream #244, which moved the config off the last flash sector
+// because it collides with BTstack's link-key bank. Reads whatever the port
+// reports as the legacy location; targets with no such location return nullptr
+// and this is a no-op.
 static bool load_old_config() {
-    const auto old_addr = get_xip_addr(PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE);
+    const void *old_addr = port::config_storage_read_legacy();
+    if (old_addr == nullptr) return false;
     uint32_t magic_header;
     memcpy(&magic_header, old_addr, sizeof(uint32_t));
-    if (magic_header == CONFIG_MAGIC) {
-        printf("[Config] Trying load old sector config\n");
-        memset(&config, 0xFF, sizeof(Config)); // 先进行 0xFF 填充，确保后续缺项能够正常初始化
-        memcpy(&config, old_addr, sizeof(Config));
-        printf("[Config] Old Config loaded\n");
-        return true;
-    }
-    return false;
+    if (magic_header != CONFIG_MAGIC) return false;
+    printf("[Config] Trying load old sector config\n");
+    memset(&config, 0xFF, sizeof(Config)); // 先进行 0xFF 填充，确保后续缺项能够正常初始化
+    memcpy(&config, old_addr, sizeof(Config));
+    printf("[Config] Old Config loaded\n");
+    return true;
 }
 
 void config_valid() {
@@ -143,36 +139,21 @@ void config_valid() {
 }
 
 void config_load() {
-    memcpy(&config, get_xip_addr(CONFIG_FLASH_OFFSET), sizeof(Config));
+    memcpy(&config, flash_config(), sizeof(Config));
 
     config_valid();
 }
 
-// Runs with core1 parked (flash_safe_execute) and core0 interrupts disabled, so
-// neither core touches XIP flash while the sector is erased/programmed. Without
-// the core1 park this races the audio core and corrupts audio (buzzing).
-static void config_save_flash_op(void *param) {
-    const auto *page = static_cast<const uint8_t *>(param);
-    const uint32_t interrupts = save_and_disable_interrupts();
-    flash_range_erase(CONFIG_FLASH_OFFSET, FLASH_SECTOR_SIZE);
-    flash_range_program(CONFIG_FLASH_OFFSET, page, FLASH_PAGE_SIZE);
-    restore_interrupts(interrupts);
-}
-
 bool config_save() {
     config.crc32 = calc_config_crc(config);
-    alignas(4) uint8_t page[FLASH_PAGE_SIZE];
-    memset(page, 0xff, sizeof(page));
-    memcpy(page, &config, sizeof(Config));
 
-    const int rc = flash_safe_execute(config_save_flash_op, page, 1000);
-    if (rc != PICO_OK) {
-        printf("[Config] config_save flash_safe_execute failed: %d\n", rc);
+    if (!port::config_storage_write(&config, sizeof(Config))) {
+        printf("[Config] config_save storage write failed\n");
         return false;
     }
 
     Config verify{};
-    memcpy(&verify, get_xip_addr(CONFIG_FLASH_OFFSET), sizeof(verify));
+    memcpy(&verify, flash_config(), sizeof(verify));
     const auto verify_crc32 = calc_config_crc(verify);
     if (verify_crc32 == config.crc32) {
         printf("[Config] Config write flash verify success\n");
@@ -200,11 +181,7 @@ void set_config(const uint8_t *new_config, const uint16_t len) {
         gpio_on_disconnect();
     }
 
-    if (config.body.disable_pico_led) {
-        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
-    }else {
-        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, true);
-    }
+    port::led_set(!config.body.disable_pico_led);
     SetStateData state{};
     if (config.body.trigger_reduce > 0) {
         state.AllowMotorPowerLevel = 1;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -2,13 +2,13 @@
 // Created by Codex on 2026/7/7.
 //
 
+#include "port/port.h"
 #include "debug.h"
 
 #if ENABLE_DEBUG
 
 #include <cstdio>
 
-#include "pico/time.h"
 
 static constexpr uint32_t DEBUG_STACK_CANARY = 0xA5A5A5A5u;
 static constexpr uint64_t DEBUG_STACK_LOG_PERIOD_US = 5'000'000;
@@ -51,7 +51,7 @@ void debug_log_core1_stack_usage() {
     }
 
     static uint64_t next_log_us = 0;
-    const uint64_t now = time_us_64();
+    const uint64_t now = port::now_us();
     if (now < next_log_us) {
         return;
     }

--- a/src/dse.cpp
+++ b/src/dse.cpp
@@ -2,13 +2,13 @@
 // DualSense Edge profile support. See dse.h for the protocol overview.
 //
 
+#include "port/port.h"
 #include "dse.h"
 #include "bt.h"
 #include <cstdio>
 #include <cstring>
 #include <vector>
 #include <unordered_map>
-#include "pico/time.h"
 
 // Provided by bt.cpp
 extern std::unordered_map<uint8_t, std::vector<uint8_t> > feature_data;
@@ -72,7 +72,7 @@ void dse_on_connect() {
     unlock[1] = 0x01;
     set_feature_data(0x80, unlock, sizeof(unlock));
     // 3) Caller connects USB immediately. Gate profile reads until ready.
-    unlock_started_ms = to_ms_since_boot(get_absolute_time());
+    unlock_started_ms = port::now_ms();
     unlock_phase = 1;
     profiles_ready = false;
 }
@@ -88,13 +88,13 @@ void dse_on_control_packet(const uint8_t *packet, uint16_t size) {
 
 void dse_on_profile_write(uint8_t reportId) {
     if (reportId >= 0x60 && reportId <= 0x62) {
-        profile_written_ms = to_ms_since_boot(get_absolute_time());
+        profile_written_ms = port::now_ms();
         post_save_round = 0;
     }
 }
 
 void dse_task() {
-    const uint32_t now = to_ms_since_boot(get_absolute_time());
+    const uint32_t now = port::now_ms();
     const uint16_t cid = bt_control_cid();
 
     // Paced prefetch sequencer: one profile GET per 80ms.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,8 +2,9 @@
 // Created by awalol on 2026/3/4.
 //
 
+#include "port/port.h"
+#include "tusb.h"
 #include <cstdio>
-#include "bsp/board_api.h"
 #include "bt.h"
 #include "button_functions.h"
 #include "utils.h"
@@ -17,10 +18,6 @@
 #ifdef ENABLE_WAKE_HID
 #include "ps_shortcut.h"
 #endif
-#include "hardware/clocks.h"
-#include "hardware/vreg.h"
-#include "hardware/watchdog.h"
-#include "pico/cyw43_arch.h"
 #if ENABLE_SERIAL
 #include "pico/stdio_usb.h"
 #endif
@@ -33,7 +30,6 @@
 #endif
 
 // Pico SDK speciifically for waiting on conditions
-#include "pico/critical_section.h"
 
 uint8_t reportSeqCounter = 0;
 uint8_t packetCounter = 0;
@@ -50,10 +46,10 @@ uint8_t interrupt_in_data[63] = {
     0x53, 0x9f, 0x28, 0x35, 0xa5, 0xa8, 0x0c, 0x8b
 };
 
-critical_section_t report_cs;
+port::CriticalSection report_cs;
 volatile bool report_dirty = false;
 
-void __not_in_flash_func(interrupt_loop)() {
+void PORT_FAST_FUNC(interrupt_loop)() {
     if (!tud_hid_ready()) return;
 
     // TODO: Refactor for better code reuse
@@ -69,13 +65,13 @@ void __not_in_flash_func(interrupt_loop)() {
     uint8_t safe_report[63];
 
 
-    critical_section_enter_blocking(&report_cs);
+    report_cs.enter();
     if (report_dirty) {
         memcpy(safe_report, interrupt_in_data, 63);
         report_dirty = false;
         should_send = true;
     }
-    critical_section_exit(&report_cs);
+    report_cs.exit();
 
     // Only send to TinyUSB if we actually grabbed fresh data
     if (should_send) {
@@ -84,14 +80,14 @@ void __not_in_flash_func(interrupt_loop)() {
 
             // If the report failed to queue, restore the dirty flag 
             // so we try again on the next loop iteration.
-            critical_section_enter_blocking(&report_cs);
+            report_cs.enter();
             report_dirty = true;
-            critical_section_exit(&report_cs);
+            report_cs.exit();
         }
     }
 }
 
-void __not_in_flash_func(on_bt_data)(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
+void PORT_FAST_FUNC(on_bt_data)(CHANNEL_TYPE channel, uint8_t *data, uint16_t len) {
     // printf("[Main] BT data callback: channel=%u len=%u\n", channel, len);
     if (channel == INTERRUPT && len > 2 && data[1] == 0x31) {
         // Mic audio: controller signals mic payload via bit1 of data[2];
@@ -145,10 +141,10 @@ void __not_in_flash_func(on_bt_data)(CHANNEL_TYPE channel, uint8_t *data, uint16
         // preventing data corruption and ensuring thread safety.
         // We also set the report_dirty flag to true to indicate that new data is available
         //  and needs to be sent in the next interrupt report.
-        critical_section_enter_blocking(&report_cs);
+        report_cs.enter();
         memcpy(interrupt_in_data, data + 3, 63);
         report_dirty = true;
-        critical_section_exit(&report_cs);
+        report_cs.exit();
 #if ENABLE_BATT_LED
         battery_led_note_report();
 #endif
@@ -270,6 +266,31 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
                 }
 
                 memcpy(outputData + 3, &state, sizeof(SetStateData));
+                if (state.AllowLedColor) {
+                    bt_note_host_led(state.LedRed, state.LedGreen, state.LedBlue);
+                }
+#if defined(DS5_FEATURE_TRACE)
+                // Quiet by design: only report when the host actually asks for a
+                // lightbar change, so rumble and trigger traffic does not drown
+                // the log. This answers whether Steam's colour changes reach us
+                // at all after a reconnect, which splits "the host stopped
+                // sending" from "the controller stopped listening".
+                {
+                    static uint8_t last_r = 0, last_g = 0, last_b = 0;
+                    static bool seen = false;
+                    if (state.AllowLedColor || state.ResetLights ||
+                        !seen || state.LedRed != last_r || state.LedGreen != last_g ||
+                        state.LedBlue != last_b) {
+                        printf("[%lu] [LED] host report: allow=%u reset=%u rgb=%02X%02X%02X fade=%u bright=%u\n",
+                               (unsigned long) port::now_ms(), (unsigned) state.AllowLedColor,
+                               (unsigned) state.ResetLights,
+                               state.LedRed, state.LedGreen, state.LedBlue,
+                               (unsigned) state.LightFadeAnimation, (unsigned) state.LightBrightness);
+                        last_r = state.LedRed; last_g = state.LedGreen; last_b = state.LedBlue;
+                        seen = true;
+                    }
+                }
+#endif
                 bt_write(outputData, sizeof(outputData));
 #if ENABLE_VERBOSE
                 printf_hexdump(outputData,sizeof(outputData));
@@ -288,56 +309,55 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
 }
 
 int main() {
-#if SYS_CLOCK_KHZ != 150000
-    vreg_set_voltage(VREG_VOLTAGE_1_20);
-    sleep_ms(1000);
-    set_sys_clock_khz(SYS_CLOCK_KHZ, true);
-#endif
+    port::clocks_init();
 
-    board_init();
+    port::board_init();
     tusb_rhport_init_t dev_init = {
         .role = TUSB_ROLE_DEVICE,
-        .speed = TUSB_SPEED_FULL
+        .speed = static_cast<tusb_speed_t>(port::kUsbSpeed)
     };
-    tusb_init(BOARD_TUD_RHPORT, &dev_init);
+    tusb_init(port::kUsbRhPort, &dev_init);
 #if !ENABLE_SERIAL
-    sleep_ms(150);
+    port::delay_ms(150);
     tud_disconnect();
 #endif
-    board_init_after_tusb();
+    port::board_init_after_tusb();
 #if ENABLE_SERIAL
     stdio_usb_init();
     while (!stdio_usb_connected()) {
         tud_task();
     }
-    sleep_ms(150);
+    port::delay_ms(150);
 #endif
 
-    if (cyw43_arch_init()) {
-        printf("Failed to initialize CYW43\n");
+    if (!port::bt_transport_init()) {
+        printf("Failed to initialize BT transport\n");
         return 1;
     }
-    cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
+    // Must precede any led_set(): on ESP32-S31 this creates the RMT handle for
+    // the addressable LED, without which led_set() silently does nothing. The
+    // Pico backend only needs it to drive the pin low, which is what the
+    // following call did on its own before.
+    port::led_init();
+    port::led_set(false);
 
-#ifdef CYW43_WL_GPIO_SMPS_PIN
-    cyw43_arch_gpio_put(CYW43_WL_GPIO_SMPS_PIN, true);
-#endif
+    port::smps_force_pwm();
 
 #if ENABLE_BATT_LED
     battery_led_init();
 #endif
 
 #if !ENABLE_SERIAL
-    if (watchdog_caused_reboot()) {
+    if (port::watchdog_caused_reboot()) {
         printf("Rebooted by Watchdog!\n");
         // 当崩溃重启以后，闪三下灯
         for (int i = 0; i < 6; i++) {
             if (i % 2 == 0) {
-                cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, true);
+                port::led_set(true);
             } else {
-                cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, false);
+                port::led_set(false);
             }
-            sleep_ms(500);
+            port::delay_ms(500);
         }
     } else {
         printf("Clean boot\n");
@@ -345,7 +365,7 @@ int main() {
 #endif
 
     // Initialize the critical section for the report buffer
-    critical_section_init(&report_cs);
+    report_cs.init();
     wake_init();
 
     config_load();
@@ -357,14 +377,15 @@ int main() {
     audio_init();
 
 #if !ENABLE_SERIAL
-    watchdog_enable(1000, true);
+    port::watchdog_enable(1000);
 #endif
 
     while (1) {
 #if !ENABLE_SERIAL
-        watchdog_update();
+        port::watchdog_update();
 #endif
-        cyw43_arch_poll();
+        port::bt_transport_poll();
+        bt_task();
         tud_task();
         wake_task();
         audio_loop();

--- a/src/port/esp32s31/board_esp32s31.h
+++ b/src/port/esp32s31/board_esp32s31.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// ESP32-S31-Function-CoreBoard-1 pin map.
+//
+// Board reference: ESP32-S31-WROOM-3 module, 16MB flash / 16MB PSRAM, USB 2.0
+// high-speed OTG, ES8311 codec + NS4150B amplifier, addressable RGB LED,
+// RJ45 gigabit Ethernet.
+//
+// Verified against the Espressif user guide:
+// documentation.espressif.com/esp-dev-kits/en/latest/esp32s31/esp32-s31-function-coreboard-1/
+
+// Addressable RGB LED (WS2812-style, driven over RMT).
+// User guide: "Addressable RGB LED, driven by GPIO60".
+#define BOARD_STATUS_LED_GPIO 60
+
+// BOOT button, active low. GPIO61, NOT GPIO0 -- 61 is the S31's boot-mode
+// strapping pin; GPIO0 is an ordinary pin on header J2 with no button, so
+// reading it would float.
+#define BOARD_BOOT_BUTTON_GPIO 61
+
+// USB: nothing to configure here; see ports/esp32s31/README.md for cabling.
+//
+// The UTMI PHY's D+/D- go to the Type-A receptacle, which does not force host
+// role -- device vs host is a software choice. The real conflict is VBUS: the
+// board sources 5V on that port through a TPS2051C whose active-high EN is
+// strapped to VCC_5V through a populated 10k and reaches no GPIO, so it cannot
+// be turned off. Use a VBUS-disconnected (data-only) A-to-A cable and power the
+// board from a Type-C port.

--- a/src/port/esp32s31/bt_transport_esp32s31.cpp
+++ b/src/port/esp32s31/bt_transport_esp32s31.cpp
@@ -1,0 +1,332 @@
+// BTstack HCI transport over the ESP32-S31 on-die controller (VHCI).
+//
+// Uses the pollable btstack_run_loop_embedded, pumped from the superloop, not
+// BTstack's port/esp32 whose FreeRTOS run loop never returns. Every BTstack
+// callback therefore runs on the main task, which the shared firmware requires:
+// bt_write() uses a single static send_element and the report counters are
+// non-atomic. The firmware is NOT single-threaded though -- the core-1 audio
+// worker and port::timer_once_ms() are elsewhere. See the threading section of
+// ports/esp32s31/README.md.
+//
+// VHCI callbacks come from the controller's own task and touch only a
+// mutex-guarded ring buffer, drained by the main task. BTstack's own deferral
+// (btstack_run_loop_execute_on_main_thread) is an unlocked list insert on the
+// embedded run loop, so the explicit ring is required.
+
+#include "../port.h"
+
+#include <cstdio>
+#include <cstring>
+
+#include "esp_bt.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+
+// Undocumented, unheadered, but a global symbol in libbredr_app.a and already
+// linked into the image (see the .map). Signature from disassembly.
+extern "C" int r_orca_log_set_level(int module, int level);
+
+extern "C" {
+#include "btstack_memory.h"
+#include "btstack_ring_buffer.h"
+#include "btstack_run_loop.h"
+#include "btstack_run_loop_embedded.h"
+#include "btstack_tlv.h"
+#include "btstack_tlv_esp32.h"
+#include "classic/btstack_link_key_db_tlv.h"
+#include "hci.h"
+#include "hci_transport.h"
+}
+
+namespace {
+
+// Sized like BTstack's own port: enough ACL packets to cover a stall plus a few
+// events. SCO is omitted -- the DualSense carries audio over L2CAP, not a voice
+// link, and the sdkconfig builds BR/EDR without SCO buffers.
+constexpr uint16_t kAclPacketLen = 1021;
+constexpr uint16_t kAclPacketNum = 8;
+constexpr uint16_t kEventPacketNum = 4;
+
+// Each entry is a 2-byte length tag plus the H4 packet (type byte + payload).
+uint8_t g_ring_storage[kAclPacketNum * (2 + 1 + HCI_ACL_HEADER_SIZE + kAclPacketLen) +
+                       kEventPacketNum * (2 + 1 + HCI_EVENT_BUFFER_SIZE)];
+
+btstack_ring_buffer_t g_ring;
+SemaphoreHandle_t g_ring_mutex = nullptr;
+
+// BTstack wants a pre-buffer ahead of the packet it is handed.
+uint8_t g_rx_with_pre_buffer[HCI_INCOMING_PRE_BUFFER_SIZE + HCI_INCOMING_PACKET_BUFFER_SIZE];
+uint8_t *const g_rx = &g_rx_with_pre_buffer[HCI_INCOMING_PRE_BUFFER_SIZE];
+
+void (*g_packet_handler)(uint8_t packet_type, uint8_t *packet, uint16_t size) = nullptr;
+
+// Set by the controller (on its own task) when it has taken the packet we
+// handed it and can accept another. Cleared by the main task, which then
+// raises HCI_EVENT_TRANSPORT_PACKET_SENT so BTstack releases its packet buffer.
+volatile bool g_tx_complete = false;
+
+// Incremented by the controller task, drained by the main task for reporting.
+volatile uint32_t g_rx_dropped = 0;
+
+bool g_controller_started = false;
+
+// ---------------------------------------------------------- VHCI callbacks
+// These run on the "BT Controller" task, not the main task.
+
+void vhci_send_available_cb() {
+    // The controller has capacity again. Harmless to note, but not what
+    // releases BTstack's buffer -- see transport_send_packet().
+    g_tx_complete = true;
+}
+
+int vhci_recv_cb(uint8_t *data, uint16_t len) {
+    if (g_ring_mutex == nullptr) return 0;
+
+    xSemaphoreTake(g_ring_mutex, portMAX_DELAY);
+    if (btstack_ring_buffer_bytes_free(&g_ring) < static_cast<uint32_t>(len) + 2) {
+        xSemaphoreGive(g_ring_mutex);
+        // Counted, not printed. This runs on the BT controller task, and the
+        // console is a blocking UART behind a mutex the main task holds
+        // constantly -- stalling the controller here would cause the very
+        // disconnects this transport exists to avoid. bt_transport_poll()
+        // reports the delta from the main task instead.
+        ++g_rx_dropped;
+        return 0;
+    }
+
+    uint8_t len_tag[2];
+    little_endian_store_16(len_tag, 0, len);
+    btstack_ring_buffer_write(&g_ring, len_tag, sizeof(len_tag));
+    btstack_ring_buffer_write(&g_ring, data, len);
+    xSemaphoreGive(g_ring_mutex);
+    return 0;
+}
+
+const esp_vhci_host_callback_t g_vhci_cb = {
+    .notify_host_send_available = vhci_send_available_cb,
+    .notify_host_recv = vhci_recv_cb,
+};
+
+// ------------------------------------------------------------- hci_transport
+
+void transport_init(const void *) {}
+
+int transport_open() {
+    btstack_ring_buffer_init(&g_ring, g_ring_storage, sizeof(g_ring_storage));
+
+    // esp_bt_controller_init() may only be called once per boot.
+    if (!g_controller_started) {
+        esp_bt_controller_config_t cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
+        esp_err_t ret = esp_bt_controller_init(&cfg);
+        if (ret != ESP_OK) {
+            printf("[BT] esp_bt_controller_init failed: %s\n", esp_err_to_name(ret));
+            return -1;
+        }
+        g_controller_started = true;
+    }
+
+    // On esp32s31 the mode argument is ignored -- controller/esp32s31/bt.c has
+    // UNUSED(mode), and BR/EDR vs LE is fixed at compile time by
+    // CONFIG_BTDM_CTRL_MODE_* (we set BR_EDR_ONLY). Passed correctly anyway so
+    // this does not become a lie if that changes.
+    const esp_err_t ret = esp_bt_controller_enable(ESP_BT_MODE_CLASSIC_BT);
+    if (ret != ESP_OK) {
+        printf("[BT] esp_bt_controller_enable failed: %s\n", esp_err_to_name(ret));
+        return -1;
+    }
+
+    // The closed BR/EDR blob has its own log framework with no Kconfig.
+    // r_orca_log_init silences all 15 modules during controller init, so changes
+    // must come after enable(). Lower is more verbose ([E]/[W] <=4, [D] <=1).
+    // Useful modules: 5 OLC (paging), 6 OLM, 8 OLM_LMP, 9 OLM_CONN. Left silent
+    // -- module 5 at level 1 buries the console while page scan runs.
+#if defined(DS5_BT_CONTROLLER_LOG)
+    r_orca_log_set_level(9, 1);
+    r_orca_log_set_level(5, 1);
+    r_orca_log_set_level(6, 4);
+    r_orca_log_set_level(8, 1);
+    r_orca_log_set_level(7, 4);
+    printf("[BT] controller internal log enabled (OLC/OLM_CONN debug)\n");
+#endif
+
+    esp_vhci_host_register_callback(&g_vhci_cb);
+    return 0;
+}
+
+int transport_close() {
+    esp_bt_controller_disable();
+    return 0;
+}
+
+void transport_register_packet_handler(void (*handler)(uint8_t, uint8_t *, uint16_t)) {
+    g_packet_handler = handler;
+}
+
+int transport_can_send_packet_now(uint8_t) {
+    return esp_vhci_host_check_send_available();
+}
+
+// Bounce buffer for outgoing packets. esp_vhci_host_send_packet() is
+// asynchronous but BTstack frees its single HCI packet buffer on
+// HCI_EVENT_TRANSPORT_PACKET_SENT, so passing BTstack's buffer lets it refill
+// that memory underneath the controller. Waiting on the send-available callback
+// instead is not viable: it only fires on a transition back to capacity, so
+// after an ordinary send it never arrives.
+uint8_t g_tx_buffer[1 + HCI_INCOMING_PACKET_BUFFER_SIZE];
+
+int transport_send_packet(uint8_t packet_type, uint8_t *packet, int size) {
+    // VHCI takes H4 framing: one type byte then the payload.
+    const int buffer_size = size + 1;
+    if (buffer_size > static_cast<int>(sizeof(g_tx_buffer))) {
+        printf("[BT] outgoing HCI packet too large: %d\n", buffer_size);
+        return -1;
+    }
+    g_tx_buffer[0] = packet_type;
+    memcpy(&g_tx_buffer[1], packet, static_cast<size_t>(size));
+    esp_vhci_host_send_packet(g_tx_buffer, buffer_size);
+
+    // Safe to release BTstack's buffer now: the controller is reading our copy,
+    // not theirs.
+    g_tx_complete = true;
+    return 0;
+}
+
+const hci_transport_t g_transport = {
+    "esp32s31-vhci",
+    &transport_init,
+    &transport_open,
+    &transport_close,
+    &transport_register_packet_handler,
+    &transport_can_send_packet_now,
+    &transport_send_packet,
+    nullptr, // set_baudrate
+    nullptr, // reset_link
+    nullptr, // set_sco_config
+};
+
+} // namespace
+
+// BTstack's embedded run loop asks for wall time via hal_time_ms() because
+// src/btstack_config.h defines HAVE_EMBEDDED_TIME_MS.
+extern "C" uint32_t hal_time_ms(void) {
+    return static_cast<uint32_t>(esp_timer_get_time() / 1000);
+}
+
+// The embedded run loop guards its trigger flag with the embedded HAL's
+// irq primitives. A FreeRTOS critical section is the SMP-correct equivalent:
+// it masks interrupts on this core and takes a spinlock. The run loop only
+// holds it around a flag test, so it stays short enough to be safe.
+namespace {
+portMUX_TYPE g_hal_mux = portMUX_INITIALIZER_UNLOCKED;
+} // namespace
+
+extern "C" void hal_cpu_disable_irqs(void) { portENTER_CRITICAL_SAFE(&g_hal_mux); }
+extern "C" void hal_cpu_enable_irqs(void) { portEXIT_CRITICAL_SAFE(&g_hal_mux); }
+
+extern "C" void hal_cpu_enable_irqs_and_sleep(void) {
+    // Deliberately does NOT sleep. The embedded run loop calls this when it has
+    // no work, but our caller is main.cpp's superloop, which still has to
+    // service TinyUSB and pet the watchdog. Sleeping here would stall USB.
+    portEXIT_CRITICAL_SAFE(&g_hal_mux);
+}
+
+namespace port {
+
+bool bt_transport_init() {
+    g_ring_mutex = xSemaphoreCreateMutex();
+    if (g_ring_mutex == nullptr) {
+        printf("[BT] could not create HCI ring mutex\n");
+        return false;
+    }
+
+    // Everything cyw43_arch_init() did for the Pico build, since bt.cpp only
+    // does sdp_init()/l2cap_init()/hci_power_control() on top.
+    btstack_memory_init();
+    btstack_run_loop_init(btstack_run_loop_embedded_get_instance());
+
+    const btstack_tlv_t *tlv = btstack_tlv_esp32_get_instance();
+    if (tlv != nullptr) {
+        // Link keys and the firmware's own blacklist tags live in NVS.
+        btstack_tlv_set_instance(tlv, nullptr);
+    } else {
+        printf("[BT] NVS-backed TLV unavailable; pairings will not persist\n");
+    }
+
+    hci_init(&g_transport, nullptr);
+
+    // AFTER hci_init(), which allocates hci_stack -- hci_set_link_key_db()
+    // dereferences it immediately -- and before hci_power_control(). Setting
+    // the TLV instance alone is not enough: link keys live behind a separate
+    // hci_stack->link_key_db, and left null it answers every
+    // HCI_Link_Key_Request negatively, so PS-only reconnect cannot work.
+    if (tlv != nullptr) {
+        hci_set_link_key_db(btstack_link_key_db_tlv_get_instance(tlv, nullptr));
+    }
+
+    return true;
+}
+
+// Synthetic "transport done with your buffer" event. BTstack releases its
+// single HCI packet buffer only on this (hci.c: HCI_EVENT_TRANSPORT_PACKET_SENT),
+// so it must fire between packets during a drain, not once at the end.
+static void emit_packet_sent_if_pending() {
+    if (!g_tx_complete) return;
+    g_tx_complete = false;
+    if (g_packet_handler == nullptr) return;
+    uint8_t event[] = {HCI_EVENT_TRANSPORT_PACKET_SENT, 0};
+    g_packet_handler(HCI_EVENT_PACKET, event, sizeof(event));
+}
+
+void bt_transport_poll() {
+    // Deliver anything the controller task queued. Copy out under the mutex,
+    // then dispatch with it released -- the handler re-enters BTstack and can
+    // end up sending, and holding the lock across that would invite deadlock.
+    while (true) {
+        // Release the packet buffer before dispatching the next event. Without
+        // this, a handler that sends (authentication_requested,
+        // link_key_request_reply, user_confirmation_reply,
+        // set_connection_encryption, disconnect -- i.e. the whole SSP path)
+        // is silently refused for the rest of the drain. Only the connect had
+        // a retry; none of the others do.
+        emit_packet_sent_if_pending();
+
+        uint32_t got = 0;
+        uint8_t len_tag[2];
+
+        xSemaphoreTake(g_ring_mutex, portMAX_DELAY);
+        if (btstack_ring_buffer_bytes_available(&g_ring) == 0) {
+            xSemaphoreGive(g_ring_mutex);
+            break;
+        }
+        btstack_ring_buffer_read(&g_ring, len_tag, sizeof(len_tag), &got);
+        const uint32_t len = little_endian_read_16(len_tag, 0);
+        btstack_ring_buffer_read(&g_ring, g_rx, len, &got);
+        xSemaphoreGive(g_ring_mutex);
+
+        if (g_packet_handler != nullptr && len >= 1) {
+            g_packet_handler(g_rx[0], &g_rx[1], static_cast<uint16_t>(len - 1));
+        }
+    }
+
+    // Dropping an HCI packet desynchronises the stack, so it must be visible --
+    // just from a context where blocking on the UART is acceptable.
+    {
+        static uint32_t reported_drops = 0;
+        const uint32_t drops = g_rx_dropped;
+        if (drops != reported_drops) {
+            printf("[BT] HCI rx ring full, dropped %lu packet(s)\n",
+                   (unsigned long) (drops - reported_drops));
+            reported_drops = drops;
+        }
+    }
+
+    // And once more for anything sent by the last handler in the drain.
+    emit_packet_sent_if_pending();
+
+    // Timers and data sources. This is the cooperative equivalent of BTstack's
+    // execute(); it returns immediately rather than owning the task.
+    btstack_run_loop_embedded_execute_once();
+}
+
+} // namespace port

--- a/src/port/esp32s31/port_esp32s31.cpp
+++ b/src/port/esp32s31/port_esp32s31.cpp
@@ -1,0 +1,428 @@
+// ESP32-S31 backend for the platform abstraction layer.
+//
+// Target board: ESP32-S31-Function-CoreBoard-1 (ESP32-S31-WROOM-3, 16MB flash,
+// 16MB PSRAM). Pin assignments live in board_esp32s31.h.
+
+#include "../port.h"
+#include "board_esp32s31.h"
+
+#include <cstdio>
+#include <cstring>
+
+#include "driver/gpio.h"
+#include "soc/soc_caps.h"
+#include "esp_mac.h"
+#include "esp_partition.h"
+#include "esp_private/usb_phy.h"
+#include "esp_system.h"
+#include "esp_task_wdt.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "led_strip.h"
+#include "tusb.h"
+
+namespace port {
+
+// ---------------------------------------------------------------- config store
+
+namespace {
+const esp_partition_t *g_config_part = nullptr;
+
+// RAM shadow of the config region. ESP-IDF cannot erase a partition while it is
+// mmap'd, so unlike the XIP-mapped RP2350 path we read into RAM and hand
+// callers a pointer to that. kConfigStoragePageSize is all the caller ever
+// writes, but the shadow covers what it may read back.
+alignas(4) uint8_t g_config_shadow[kConfigStoragePageSize];
+bool g_config_loaded = false;
+
+const esp_partition_t *config_partition() {
+    if (!g_config_part) {
+        g_config_part = esp_partition_find_first(
+            ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "config");
+    }
+    return g_config_part;
+}
+} // namespace
+
+const void *config_storage_read() {
+    if (!g_config_loaded) {
+        const esp_partition_t *part = config_partition();
+        if (part && esp_partition_read(part, 0, g_config_shadow, sizeof(g_config_shadow)) == ESP_OK) {
+            g_config_loaded = true;
+        } else {
+            // Present erased flash so the caller's magic/CRC check fails and it
+            // falls back to defaults, matching a blank Pico.
+            memset(g_config_shadow, 0xff, sizeof(g_config_shadow));
+            g_config_loaded = true;
+        }
+    }
+    return g_config_shadow;
+}
+
+const void *config_storage_read_legacy() {
+    // No legacy location: this port has always used its own "config" partition,
+    // so there is nothing to migrate from.
+    return nullptr;
+}
+
+bool config_storage_write(const void *data, size_t len) {
+    if (len > kConfigStoragePageSize) return false;
+
+    const esp_partition_t *part = config_partition();
+    if (!part) {
+        printf("[Port] config partition not found\n");
+        return false;
+    }
+
+    alignas(4) uint8_t page[kConfigStoragePageSize];
+    memset(page, 0xff, sizeof(page));
+    memcpy(page, data, len);
+
+    // esp_partition_erase_range takes the flash-op lock internally, which parks
+    // the other core's cache access for the duration -- the equivalent of the
+    // Pico build's flash_safe_execute core1 park.
+    esp_err_t err = esp_partition_erase_range(part, 0, kConfigStorageSize);
+    if (err != ESP_OK) {
+        printf("[Port] config erase failed: %d\n", err);
+        return false;
+    }
+    err = esp_partition_write(part, 0, page, sizeof(page));
+    if (err != ESP_OK) {
+        printf("[Port] config write failed: %d\n", err);
+        return false;
+    }
+
+    memcpy(g_config_shadow, page, sizeof(page));
+    g_config_loaded = true;
+    return true;
+}
+
+// ----------------------------------------------------------------- one-shot timer
+
+namespace {
+constexpr int kMaxTimers = 4;
+
+struct TimerSlot {
+    void (*cb)(void *);
+    void *ctx;
+    // Created on first use and then kept forever. Never deleting the handle is
+    // what makes cancel safe: esp_timer_stop() on a stale-but-live handle is
+    // merely ESP_ERR_INVALID_STATE, whereas stopping a freed one corrupts the
+    // esp_timer list and panics minutes later with an unrelated backtrace.
+    esp_timer_handle_t handle;
+    // Ownership token. Claimed by an atomic exchange so exactly one context --
+    // the arming caller, the cancelling caller, or the trampoline -- ever acts
+    // on a given slot. The trampoline runs on the esp_timer task (priority 22)
+    // while callers are typically the main task (priority 1) on the same core,
+    // so this is a genuine preemption, not a theoretical one.
+    volatile bool armed;
+};
+
+TimerSlot g_slots[kMaxTimers];
+
+void timer_trampoline(void *arg) {
+    auto *slot = static_cast<TimerSlot *>(arg);
+    // Release before running so the callback may re-arm, matching the Pico
+    // backend. Losing this exchange means a cancel got here first.
+    if (!__atomic_exchange_n(&slot->armed, false, __ATOMIC_SEQ_CST)) return;
+    slot->cb(slot->ctx);
+}
+} // namespace
+
+TimerId timer_once_ms(uint32_t delay_ms, void (*cb)(void *), void *ctx) {
+    for (int i = 0; i < kMaxTimers; ++i) {
+        bool expected = false;
+        if (!__atomic_compare_exchange_n(&g_slots[i].armed, &expected, true,
+                                         false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)) {
+            continue; // in use
+        }
+
+        // The slot is ours now, so lazily creating the handle here is safe.
+        if (g_slots[i].handle == nullptr) {
+            const esp_timer_create_args_t args = {
+                .callback = timer_trampoline,
+                .arg = &g_slots[i],
+                .dispatch_method = ESP_TIMER_TASK,
+                .name = "port_oneshot",
+                .skip_unhandled_events = true,
+            };
+            if (esp_timer_create(&args, &g_slots[i].handle) != ESP_OK) {
+                __atomic_store_n(&g_slots[i].armed, false, __ATOMIC_SEQ_CST);
+                return kNoTimer;
+            }
+        }
+
+        // Published before the timer can possibly fire, since it is not started
+        // until the next statement.
+        g_slots[i].cb = cb;
+        g_slots[i].ctx = ctx;
+
+        if (esp_timer_start_once(g_slots[i].handle,
+                                 static_cast<uint64_t>(delay_ms) * 1000) != ESP_OK) {
+            __atomic_store_n(&g_slots[i].armed, false, __ATOMIC_SEQ_CST);
+            return kNoTimer;
+        }
+        return static_cast<TimerId>(i + 1); // 0 is reserved for kNoTimer
+    }
+    return kNoTimer;
+}
+
+void timer_cancel(TimerId id) {
+    // TimerId is int32_t: reject <= 0, not just == kNoTimer. A negative id
+    // passed the old check and indexed g_slots[id - 1] out of bounds.
+    if (id <= kNoTimer || id > kMaxTimers) return;
+    TimerSlot &slot = g_slots[id - 1];
+    // Losing this exchange means it already fired; there is nothing to stop and
+    // the trampoline owns the slot.
+    if (!__atomic_exchange_n(&slot.armed, false, __ATOMIC_SEQ_CST)) return;
+    esp_timer_stop(slot.handle);
+}
+
+// ------------------------------------------------------------------ boot button
+
+bool boot_button_pressed() {
+    static bool configured = false;
+    if (!configured) {
+        const gpio_config_t cfg = {
+            .pin_bit_mask = 1ULL << BOARD_BOOT_BUTTON_GPIO,
+            .mode = GPIO_MODE_INPUT,
+            .pull_up_en = GPIO_PULLUP_ENABLE,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .intr_type = GPIO_INTR_DISABLE,
+        };
+        gpio_config(&cfg);
+        configured = true;
+    }
+    // BOOT is active-low. Unlike the RP2350 QSPI-CSn trick this is a cheap read
+    // with no core parking, so the 10 Hz cadence upstream is conservative here.
+    return gpio_get_level(static_cast<gpio_num_t>(BOARD_BOOT_BUTTON_GPIO)) == 0;
+}
+
+void worker_flash_safe_init() {
+    // No-op: esp_partition_* handles cross-core cache coordination itself, so
+    // the worker core needs no registration.
+}
+
+// ---------------------------------------------------------------------- system
+
+void clocks_init() {
+    // CPU frequency comes from sdkconfig (CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ) and
+    // is applied by the bootloader before app_main, so there is nothing to do.
+}
+
+void smps_force_pwm() {
+    // The board's regulator has no software-controlled mode pin.
+}
+
+bool watchdog_caused_reboot() {
+    const esp_reset_reason_t reason = esp_reset_reason();
+    return reason == ESP_RST_TASK_WDT || reason == ESP_RST_INT_WDT || reason == ESP_RST_WDT;
+}
+
+void watchdog_enable(uint32_t timeout_ms) {
+    const esp_task_wdt_config_t cfg = {
+        .timeout_ms = timeout_ms,
+        .idle_core_mask = 0, // the audio worker never idles; do not watch idle tasks
+        .trigger_panic = true,
+    };
+    // Already-initialised is fine: sdkconfig may enable the TWDT at startup.
+    esp_err_t err = esp_task_wdt_init(&cfg);
+    if (err == ESP_ERR_INVALID_STATE) err = esp_task_wdt_reconfigure(&cfg);
+    if (err != ESP_OK) {
+        printf("[Port] task wdt init failed: %d\n", err);
+        return;
+    }
+    esp_task_wdt_add(nullptr); // watch the calling (main loop) task
+}
+
+void watchdog_update() { esp_task_wdt_reset(); }
+
+[[noreturn]] void reboot() {
+    esp_restart();
+    __builtin_unreachable();
+}
+
+bool has_bootloader_reboot() { return false; }
+
+[[noreturn]] void reboot_to_bootloader() {
+    // Unreachable in practice -- button_functions.cpp checks the capability
+    // first -- but the port interface requires a definition, so keep it honest
+    // rather than silently pretending a plain restart is a flash mode.
+    printf("[Port] no software route to download boot on ESP32-S31; hold BOOT "
+           "(GPIO61) while resetting, or just let esptool do it\n");
+    esp_restart();
+    __builtin_unreachable();
+}
+
+// bt_transport_init()/bt_transport_poll() live in bt_transport_esp32s31.cpp.
+
+// ------------------------------------------------------------------------ GPIO
+
+const uint32_t kNumGpioPins = SOC_GPIO_PIN_COUNT;
+
+void gpio_init_output(uint32_t pin) {
+    const gpio_config_t cfg = {
+        .pin_bit_mask = 1ULL << pin,
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&cfg);
+    gpio_write(pin, false);
+}
+
+void gpio_write(uint32_t pin, bool level) {
+    gpio_set_level(static_cast<gpio_num_t>(pin), level ? 1 : 0);
+}
+
+// ------------------------------------------------------------------------- LED
+
+namespace {
+led_strip_handle_t g_led = nullptr;
+} // namespace
+
+void led_init() {
+    // GPIO60 reaches the WS2812 through Q1 (LBSS138) as a level shifter to 5V.
+    // That stage is NON-inverting: the gate is tied to ESP_3V3, GPIO60 drives
+    // the source and RGB_CTRL is the drain with R13 pulling to VCC_5V, so
+    // RGB_CTRL simply follows GPIO60. Do not set invert_out.
+    const led_strip_config_t strip_cfg = {
+        .strip_gpio_num = BOARD_STATUS_LED_GPIO,
+        .max_leds = 1,
+    };
+    const led_strip_rmt_config_t rmt_cfg = {
+        .resolution_hz = 10 * 1000 * 1000, // 10 MHz
+    };
+    if (led_strip_new_rmt_device(&strip_cfg, &rmt_cfg, &g_led) != ESP_OK) {
+        printf("[Port] status LED init failed\n");
+        g_led = nullptr;
+        return;
+    }
+    led_set(false);
+}
+
+void led_set(bool on) {
+    if (!g_led) return;
+    if (on) {
+        // Dim white: the board LED is far brighter than the Pico2W's, and this
+        // interface only promises on/off.
+        led_strip_set_pixel(g_led, 0, 8, 8, 8);
+        led_strip_refresh(g_led);
+    } else {
+        led_strip_clear(g_led);
+    }
+}
+
+// ---------------------------------------------------------------------------- USB
+
+const uint8_t kUsbRhPort = 0;
+
+// The S31's OTG has a UTMI (high-speed) PHY and no FS/LS transceiver
+// (soc_caps.h: SOC_USB_FSLS_PHY_NUM 0). This target enumerates HIGH speed,
+// matching the real DualSense, so PHY and requested speed agree. The RP2350 is
+// full-speed only; ep_interval() encodes bInterval for whichever is built.
+const uint8_t kUsbSpeed = TUSB_SPEED_HIGH;
+
+namespace {
+usb_phy_handle_t g_usb_phy = nullptr;
+} // namespace
+
+void board_init() {
+    // Raw TinyUSB, not esp_tinyusb, so nothing else brings the OTG PHY up --
+    // do it before tusb_init(). Device mode on the UTMI PHY is purely a
+    // software choice; the Type-A receptacle does not force host role.
+    //
+    // otg_io_conf stays null deliberately: unset means drvvbus is never routed
+    // and the SoC never drives VBUS. Board VBUS comes from a separate TPS2051C,
+    // hence the VBUS-disconnected host cable. With no VBUS sense the device
+    // attaches whenever powered rather than when the host appears.
+    const usb_phy_config_t phy_cfg = {
+        .controller = USB_PHY_CTRL_OTG,
+        .target = USB_PHY_TARGET_UTMI,
+        .otg_mode = USB_OTG_MODE_DEVICE,
+        .otg_speed = USB_PHY_SPEED_HIGH,
+        .ext_io_conf = nullptr,
+        .otg_io_conf = nullptr,
+    };
+    const esp_err_t err = usb_new_phy(&phy_cfg, &g_usb_phy);
+    if (err != ESP_OK) {
+        printf("[Port] usb_new_phy failed: %d\n", err);
+        g_usb_phy = nullptr;
+    }
+}
+
+namespace {
+
+// Report the speed dcd_init() settled on. Deliberately read-only: the speed is
+// settled by BOARD_TUD_MAX_SPEED in ports/esp32s31/CMakeLists.txt, and forcing
+// DCFG.DevSpd here instead stopped the host enumerating the device at all.
+// Worth logging, since DevSpd decides which speed the descriptors are encoded
+// for -- see ep_interval() in src/usb_descriptors.cpp.
+void usb_log_speed() {
+    // ESP32-S31 OTG_HS base, per TinyUSB's dwc2_esp32.h controller table.
+    // DCFG is at 0x800 with DevSpd in bits [1:0]:
+    //   0 = high speed, 1 = full speed on HS PHY, 2 = low speed, 3 = full speed
+    static const char *const kDevSpdName[] = {"high", "full (HS PHY)", "low", "full (FS PHY)"};
+    constexpr uintptr_t kOtgHsBase = 0x20300000UL;
+    constexpr uintptr_t kDcfgOffset = 0x800;
+
+    // DSTS at 0x808 reports what the link actually enumerated at, in bits [2:1],
+    // using the same encoding. DevSpd is what we asked for; DSTS is what we got,
+    // and only the second one is evidence.
+    constexpr uintptr_t kDstsOffset = 0x808;
+    const uint32_t dcfg = *reinterpret_cast<volatile uint32_t *>(kOtgHsBase + kDcfgOffset);
+    const uint32_t dsts = *reinterpret_cast<volatile uint32_t *>(kOtgHsBase + kDstsOffset);
+    printf("[USB] DCFG %08lX DevSpd %lu (%s), DSTS %08lX enum %lu (%s)\n",
+           (unsigned long) dcfg, (unsigned long) (dcfg & 0x3u), kDevSpdName[dcfg & 0x3u],
+           (unsigned long) dsts, (unsigned long) ((dsts >> 1) & 0x3u),
+           kDevSpdName[(dsts >> 1) & 0x3u]);
+}
+
+} // namespace
+
+void board_init_after_tusb() {
+    usb_log_speed();
+}
+
+size_t usb_get_serial(uint16_t *desc_str, size_t max_chars) {
+    // Derive a stable serial from the factory MAC, mirroring what TinyUSB's BSP
+    // does with the RP2350 unique flash ID.
+    uint8_t mac[6] = {};
+    if (esp_efuse_mac_get_default(mac) != ESP_OK) return 0;
+
+    static const char hex[] = "0123456789ABCDEF";
+    size_t n = 0;
+    for (size_t i = 0; i < sizeof(mac) && n + 2 <= max_chars; ++i) {
+        desc_str[n++] = static_cast<uint16_t>(hex[mac[i] >> 4]);
+        desc_str[n++] = static_cast<uint16_t>(hex[mac[i] & 0x0f]);
+    }
+    return n;
+}
+
+// ---------------------------------------------------------------------- worker
+
+namespace {
+StaticTask_t g_worker_tcb;
+void (*g_worker_entry)() = nullptr;
+
+void worker_thunk(void *) {
+    if (g_worker_entry) g_worker_entry();
+    vTaskDelete(nullptr); // entry is not expected to return
+}
+} // namespace
+
+void launch_worker(void (*entry)(), uint32_t *stack, size_t stack_bytes) {
+    g_worker_entry = entry;
+    // Static allocation from the caller's buffer, pinned to core 1 -- keeps the
+    // audio worker's stack where the Pico build had it so the high-water-mark
+    // instrumentation still measures the same memory.
+    xTaskCreateStaticPinnedToCore(worker_thunk, "audio_core1",
+                                  stack_bytes / sizeof(StackType_t),
+                                  nullptr, configMAX_PRIORITIES - 2,
+                                  reinterpret_cast<StackType_t *>(stack),
+                                  &g_worker_tcb, 1);
+}
+
+} // namespace port

--- a/src/port/esp32s31/port_flash_impl.h
+++ b/src/port/esp32s31/port_flash_impl.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+
+namespace port {
+
+// Matches the "config" entry in partitions_esp32s31.csv. Hard-coded rather than
+// taken from SPI_FLASH_SEC_SIZE so a change to the partition table has to be
+// made in both places deliberately.
+constexpr size_t kConfigStorageSize = 4096;
+constexpr size_t kConfigStoragePageSize = 256;
+
+} // namespace port

--- a/src/port/esp32s31/port_queue_impl.h
+++ b/src/port/esp32s31/port_queue_impl.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstddef>
+
+#include "esp_attr.h"
+#include "esp_heap_caps.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+
+namespace port {
+
+class Queue {
+public:
+    void init(size_t element_size, size_t count) {
+        q_ = xQueueCreate(count, element_size);
+        // A null handle here means the queue silently swallows every element,
+        // which on the audio path looks like glitching rather than a fault.
+        configASSERT(q_ != nullptr);
+
+        // Scratch destination for discard-oldest removals; see try_remove().
+        scratch_ = heap_caps_malloc(element_size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
+        configASSERT(scratch_ != nullptr);
+    }
+
+    // pico_util queues are callable from either context, so the ISR-safe
+    // variant is selected at runtime rather than pushed onto callers.
+    bool IRAM_ATTR try_add(const void *src) {
+        if (xPortInIsrContext()) {
+            BaseType_t woken = pdFALSE;
+            const BaseType_t ok = xQueueSendFromISR(q_, src, &woken);
+            if (woken) portYIELD_FROM_ISR();
+            return ok == pdTRUE;
+        }
+        return xQueueSend(q_, src, 0) == pdTRUE;
+    }
+
+    // A null destination means "discard the oldest element". pico_util supports
+    // that directly -- queue_remove_internal() guards its memcpy with
+    // `if (data)` -- and seven call sites rely on it to drop samples when a
+    // FIFO backs up (audio.cpp and bt.cpp's send_fifo).
+    //
+    // FreeRTOS has no discard primitive and instead asserts
+    // `!(pvBuffer == NULL && uxItemSize != 0)`, so forwarding a null through
+    // would abort on the first dropped frame -- or, with asserts compiled out,
+    // memcpy to address 0. Drain into per-queue scratch instead.
+    bool IRAM_ATTR try_remove(void *dst) {
+        void *dest = (dst != nullptr) ? dst : scratch_;
+        if (xPortInIsrContext()) {
+            BaseType_t woken = pdFALSE;
+            const BaseType_t ok = xQueueReceiveFromISR(q_, dest, &woken);
+            if (woken) portYIELD_FROM_ISR();
+            return ok == pdTRUE;
+        }
+        return xQueueReceive(q_, dest, 0) == pdTRUE;
+    }
+
+    size_t level() {
+        return xPortInIsrContext() ? uxQueueMessagesWaitingFromISR(q_)
+                                   : uxQueueMessagesWaiting(q_);
+    }
+
+    bool is_full() { return uxQueueSpacesAvailable(q_) == 0; }
+    bool is_empty() { return level() == 0; }
+
+private:
+    QueueHandle_t q_ = nullptr;
+    void *scratch_ = nullptr;
+};
+
+} // namespace port

--- a/src/port/esp32s31/port_sync_impl.h
+++ b/src/port/esp32s31/port_sync_impl.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+namespace port {
+
+class CriticalSection {
+public:
+    void init() { mux_ = (portMUX_TYPE) portMUX_INITIALIZER_UNLOCKED; }
+    void enter() { portENTER_CRITICAL_SAFE(&mux_); }
+    void exit() { portEXIT_CRITICAL_SAFE(&mux_); }
+
+private:
+    // _SAFE variants pick the ISR-correct path at runtime, so a section may be
+    // shared between task and ISR context the way the pico-sdk one was.
+    portMUX_TYPE mux_ = portMUX_INITIALIZER_UNLOCKED;
+};
+
+using irq_state_t = uint32_t;
+
+inline irq_state_t irq_save() { return portSET_INTERRUPT_MASK_FROM_ISR(); }
+inline void irq_restore(irq_state_t state) { portCLEAR_INTERRUPT_MASK_FROM_ISR(state); }
+
+} // namespace port

--- a/src/port/esp32s31/port_time_impl.h
+++ b/src/port/esp32s31/port_time_impl.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "esp_timer.h"
+#include "esp_rom_sys.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+namespace port {
+
+inline uint64_t now_us() { return static_cast<uint64_t>(esp_timer_get_time()); }
+inline uint32_t now_us32() { return static_cast<uint32_t>(esp_timer_get_time()); }
+inline uint32_t now_ms() { return static_cast<uint32_t>(esp_timer_get_time() / 1000); }
+
+inline void delay_ms(uint32_t ms) {
+    // Sub-tick sleeps would round down to zero and spin; busy-wait those so the
+    // caller still gets the delay it asked for.
+    const uint32_t tick_ms = portTICK_PERIOD_MS;
+    if (ms >= tick_ms) {
+        vTaskDelay(ms / tick_ms);
+        ms %= tick_ms;
+    }
+    if (ms) esp_rom_delay_us(ms * 1000);
+}
+
+inline void delay_us(uint32_t us) { esp_rom_delay_us(us); }
+
+inline void spin_hint() { __asm__ __volatile__("nop"); }
+
+} // namespace port

--- a/src/port/pico/port_flash_impl.h
+++ b/src/port/pico/port_flash_impl.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstddef>
+
+#include "hardware/flash.h"
+
+namespace port {
+
+constexpr size_t kConfigStorageSize = FLASH_SECTOR_SIZE;
+constexpr size_t kConfigStoragePageSize = FLASH_PAGE_SIZE;
+
+} // namespace port

--- a/src/port/pico/port_pico.cpp
+++ b/src/port/pico/port_pico.cpp
@@ -1,0 +1,250 @@
+// RP2040/RP2350 backend for the platform abstraction layer.
+
+#include "../port.h"
+
+#include <cstdio>
+#include <cstring>
+
+#include "bsp/board_api.h"
+
+#include "hardware/clocks.h"
+#include "hardware/flash.h"
+#include "pico/btstack_flash_bank.h"
+#include "hardware/gpio.h"
+#include "hardware/structs/ioqspi.h"
+#include "hardware/structs/sio.h"
+#include "hardware/sync.h"
+#include "hardware/vreg.h"
+#include "hardware/watchdog.h"
+#include "pico/bootrom.h"
+#include "pico/cyw43_arch.h"
+#include "pico/flash.h"
+#include "pico/multicore.h"
+#include "pico/time.h"
+
+namespace port {
+
+// ---------------------------------------------------------------- config store
+
+// The config lives in the last sector of flash. Keep this in step with the
+// ESP32-S31 backend's partition entry.
+// Upstream #244: the config used to live in the very last flash sector, which
+// collides with BTstack's link-key bank. It now sits just below that bank.
+static constexpr uint32_t kConfigOffset = PICO_FLASH_BANK_STORAGE_OFFSET - kConfigStorageSize;
+static constexpr uint32_t kLegacyConfigOffset = PICO_FLASH_SIZE_BYTES - kConfigStorageSize;
+
+static_assert(kConfigOffset % kConfigStorageSize == 0,
+              "config region must be sector aligned");
+
+const void *config_storage_read() {
+    return reinterpret_cast<const void *>(XIP_BASE + kConfigOffset);
+}
+
+const void *config_storage_read_legacy() {
+    return reinterpret_cast<const void *>(XIP_BASE + kLegacyConfigOffset);
+}
+
+// Runs with core1 parked (flash_safe_execute) and core0 interrupts disabled, so
+// neither core touches XIP flash while the sector is erased/programmed. Without
+// the core1 park this races the audio core and corrupts audio (buzzing).
+static void config_flash_op(void *param) {
+    const uint8_t *page = static_cast<const uint8_t *>(param);
+    const uint32_t interrupts = save_and_disable_interrupts();
+    flash_range_erase(kConfigOffset, kConfigStorageSize);
+    flash_range_program(kConfigOffset, page, kConfigStoragePageSize);
+    restore_interrupts(interrupts);
+}
+
+bool config_storage_write(const void *data, size_t len) {
+    if (len > kConfigStoragePageSize) return false;
+
+    alignas(4) uint8_t page[kConfigStoragePageSize];
+    memset(page, 0xff, sizeof(page));
+    memcpy(page, data, len);
+
+    const int rc = flash_safe_execute(config_flash_op, page, 1000);
+    if (rc != PICO_OK) {
+        printf("[Port] config_storage_write flash_safe_execute failed: %d\n", rc);
+        return false;
+    }
+    return true;
+}
+
+// ------------------------------------------------------------------ boot button
+
+// Read BOOTSEL by briefly floating the QSPI CSn line. Must run with both cores
+// in a known-safe state - if core 1 does an XIP read while CSn is floating it
+// gets garbage and the CYW43 driver misbehaves (immediate BT disconnect on audio
+// start). flash_safe_execute() handles the multicore coordination - the same SDK
+// mechanism BTstack uses for its TLV flash writes.
+static void __no_inline_not_in_flash_func(button_read_cb)(void *param) {
+    bool *out = (bool *) param;
+    const uint CS_PIN_INDEX = 1;
+
+    hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,
+                    GPIO_OVERRIDE_LOW << IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_LSB,
+                    IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_BITS);
+
+    for (volatile int i = 0; i < 1000; ++i);
+
+#if PICO_RP2350
+    *out = !(sio_hw->gpio_hi_in & SIO_GPIO_HI_IN_QSPI_CSN_BITS);
+#else
+    *out = !(sio_hw->gpio_hi_in & (1u << CS_PIN_INDEX));
+#endif
+
+    hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,
+                    GPIO_OVERRIDE_NORMAL << IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_LSB,
+                    IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_BITS);
+}
+
+bool boot_button_pressed() {
+    bool pressed = false;
+    // 100 ms timeout for the safe-state coordination; the poll is gated on the
+    // 10 Hz cadence and the safe-execute parks core1, so this never runs during
+    // active audio reads anyway.
+    const int rc = flash_safe_execute(button_read_cb, &pressed, 100);
+    if (rc != PICO_OK) return false;
+    return pressed;
+}
+
+void worker_flash_safe_init() { flash_safe_execute_core_init(); }
+
+// ---------------------------------------------------------------------- system
+
+void clocks_init() {
+#if SYS_CLOCK_KHZ != 150000
+    vreg_set_voltage(VREG_VOLTAGE_1_20);
+    sleep_ms(1000);
+    set_sys_clock_khz(SYS_CLOCK_KHZ, true);
+#endif
+}
+
+void smps_force_pwm() {
+#ifdef CYW43_WL_GPIO_SMPS_PIN
+    cyw43_arch_gpio_put(CYW43_WL_GPIO_SMPS_PIN, true);
+#endif
+}
+
+bool watchdog_caused_reboot() { return ::watchdog_caused_reboot(); }
+void watchdog_enable(uint32_t timeout_ms) { ::watchdog_enable(timeout_ms, true); }
+void watchdog_update() { ::watchdog_update(); }
+
+[[noreturn]] void reboot() {
+    // A Cortex-M33 SYSRESETREQ does a warm reset that re-runs the flash app; a
+    // watchdog reset instead drops the RP2350 bootrom into BOOTSEL, which is
+    // why watchdog_reboot/enable bricked.
+    *((volatile uint32_t *) 0xe000ed0c) = 0x05fa0004; // SCB AIRCR: VECTKEY | SYSRESETREQ
+    __dsb();
+    while (true) { tight_loop_contents(); } // wait for the reset
+}
+
+bool has_bootloader_reboot() { return true; }
+
+[[noreturn]] void reboot_to_bootloader() {
+    reset_usb_boot(0, 0); // noreturn
+    __builtin_unreachable();
+}
+
+bool bt_transport_init() { return cyw43_arch_init() == 0; }
+void bt_transport_poll() { cyw43_arch_poll(); }
+
+// ------------------------------------------------------------------------ GPIO
+
+const uint32_t kNumGpioPins = NUM_BANK0_GPIOS;
+
+void gpio_init_output(uint32_t pin) {
+    gpio_init(pin);
+    gpio_set_dir(pin, GPIO_OUT);
+    gpio_put(pin, false);
+}
+
+void gpio_write(uint32_t pin, bool level) { gpio_put(pin, level); }
+
+// ------------------------------------------------------------------------- LED
+
+void led_init() { led_set(false); }
+void led_set(bool on) { cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, on); }
+
+// ----------------------------------------------------------------- one-shot timer
+
+namespace {
+// Fixed pool rather than new/delete: a cancelled alarm never reaches its
+// callback, so a heap-allocated trampoline would leak on every cancel (which
+// happens on each controller disconnect).
+constexpr int kMaxTimers = 4;
+
+struct TimerSlot {
+    void (*cb)(void *);
+    void *ctx;
+    alarm_id_t alarm;     // valid only while busy
+    volatile bool busy;   // owns the slot; claimed BEFORE the alarm is armed
+};
+
+TimerSlot g_slots[kMaxTimers];
+
+// The pico alarm API hands the callback an alarm_id and expects a repeat delay
+// back; the port contract is a plain one-shot, so adapt both ends here.
+int64_t timer_trampoline(alarm_id_t, void *user_data) {
+    auto *slot = static_cast<TimerSlot *>(user_data);
+    const auto cb = slot->cb;
+    void *ctx = slot->ctx;
+    slot->busy = false; // release before running, so cb may re-arm
+    cb(ctx);
+    return 0; // do not reschedule
+}
+} // namespace
+
+TimerId timer_once_ms(uint32_t delay_ms, void (*cb)(void *), void *ctx) {
+    for (int i = 0; i < kMaxTimers; ++i) {
+        if (g_slots[i].busy) continue;
+        g_slots[i].cb = cb;
+        g_slots[i].ctx = ctx;
+        // Claim the slot BEFORE arming. The trampoline runs in the alarm IRQ and
+        // releases the slot; if it fired between add_alarm_in_ms() returning and
+        // a later store here, that store would resurrect a slot the trampoline
+        // had already freed and leak it permanently. Ownership is the busy flag,
+        // and alarm is only read while busy, so a stale id after release is
+        // harmless.
+        g_slots[i].busy = true;
+        const alarm_id_t id = add_alarm_in_ms(delay_ms, timer_trampoline, &g_slots[i], false);
+        if (id <= 0) {
+            g_slots[i].busy = false;
+            return kNoTimer;
+        }
+        g_slots[i].alarm = id;
+        return static_cast<TimerId>(i + 1); // 0 is reserved for kNoTimer
+    }
+    return kNoTimer;
+}
+
+void timer_cancel(TimerId id) {
+    // TimerId is int32_t, so reject <= 0 rather than just == kNoTimer: a negative
+    // id passed the old `id > kMaxTimers` check and indexed g_slots[id - 1] out
+    // of bounds, writing through it.
+    if (id <= kNoTimer || id > kMaxTimers) return;
+    TimerSlot &slot = g_slots[id - 1];
+    if (!slot.busy) return; // already fired
+    cancel_alarm(slot.alarm);
+    slot.busy = false;
+}
+
+// ---------------------------------------------------------------------- worker
+
+void launch_worker(void (*entry)(), uint32_t *stack, size_t stack_bytes) {
+    multicore_launch_core1_with_stack(entry, stack, stack_bytes);
+}
+
+// ---------------------------------------------------------------------------- USB
+
+const uint8_t kUsbRhPort = BOARD_TUD_RHPORT;
+const uint8_t kUsbSpeed = TUSB_SPEED_FULL; // RP2350 has no high-speed PHY
+
+void board_init() { ::board_init(); }
+void board_init_after_tusb() { ::board_init_after_tusb(); }
+
+size_t usb_get_serial(uint16_t *desc_str, size_t max_chars) {
+    return board_usb_get_serial(desc_str, max_chars);
+}
+
+} // namespace port

--- a/src/port/pico/port_queue_impl.h
+++ b/src/port/pico/port_queue_impl.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "pico/util/queue.h"
+
+namespace port {
+
+class Queue {
+public:
+    void init(size_t element_size, size_t count) {
+        queue_init(&q_, element_size, static_cast<uint>(count));
+    }
+
+    bool try_add(const void *src) { return queue_try_add(&q_, src); }
+    bool try_remove(void *dst) { return queue_try_remove(&q_, dst); }
+
+    size_t level() { return queue_get_level(&q_); }
+    bool is_full() { return queue_is_full(&q_); }
+    bool is_empty() { return queue_is_empty(&q_); }
+
+private:
+    queue_t q_{};
+};
+
+} // namespace port

--- a/src/port/pico/port_sync_impl.h
+++ b/src/port/pico/port_sync_impl.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+#include "pico/critical_section.h"
+#include "hardware/sync.h"
+
+namespace port {
+
+class CriticalSection {
+public:
+    void init() { critical_section_init(&cs_); }
+    void enter() { critical_section_enter_blocking(&cs_); }
+    void exit() { critical_section_exit(&cs_); }
+
+private:
+    critical_section_t cs_{};
+};
+
+using irq_state_t = uint32_t;
+
+inline irq_state_t irq_save() { return save_and_disable_interrupts(); }
+inline void irq_restore(irq_state_t state) { restore_interrupts(state); }
+
+} // namespace port

--- a/src/port/pico/port_time_impl.h
+++ b/src/port/pico/port_time_impl.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "pico.h"
+#include "pico/time.h"
+
+namespace port {
+
+inline uint64_t now_us() { return time_us_64(); }
+inline uint32_t now_us32() { return time_us_32(); }
+inline uint32_t now_ms() { return to_ms_since_boot(get_absolute_time()); }
+
+inline void delay_ms(uint32_t ms) { sleep_ms(ms); }
+inline void delay_us(uint32_t us) { sleep_us(us); }
+
+inline void spin_hint() { tight_loop_contents(); }
+
+} // namespace port

--- a/src/port/port.h
+++ b/src/port/port.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// Platform abstraction layer.
+//
+// The Pico backends are inline wrappers over the pico-sdk, so migrating a call
+// site to the port API must not change codegen — that matters because
+// cmake/relocate_to_ram.cmake tunes this firmware by pulling specific hot
+// functions into RAM.
+
+#include "port_platform.h"
+#include "port_mem.h"
+#include "port_time.h"
+#include "port_timer.h"
+#include "port_sync.h"
+#include "port_queue.h"
+#include "port_sys.h"
+#include "port_gpio.h"
+#include "port_led.h"
+#include "port_thread.h"
+#include "port_usb.h"
+#include "port_flash.h"

--- a/src/port/port_flash.h
+++ b/src/port/port_flash.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Persistent storage for the single config record.
+//
+// The RP2350 build maps the last flash sector directly (XIP) and erases it in
+// place; ESP-IDF cannot erase a partition that is currently mmap'd, so the
+// ESP32-S31 backend keeps a RAM shadow and re-reads after each write. Callers
+// must therefore treat the returned pointer as valid only until the next
+// config_storage_write() — which is how the existing code already uses it.
+
+#if defined(PORT_PLATFORM_PICO)
+#include "pico/port_flash_impl.h"
+#elif defined(PORT_PLATFORM_ESP32S31)
+#include "esp32s31/port_flash_impl.h"
+#endif
+
+namespace port {
+
+// kConfigStorageSize / kConfigStoragePageSize come from the impl header above
+// as constants, so config.cpp can keep asserting its record fits at compile
+// time rather than discovering it at runtime.
+
+// Stable, readable view of the persisted bytes. Never null.
+const void *config_storage_read();
+
+// Pointer to the *previous* config location, for one-time migration, or nullptr
+// on targets that never had one. RP2350 kept the config in the last flash
+// sector until upstream #244 moved it clear of BTstack's link-key bank.
+const void *config_storage_read_legacy();
+
+// Erase the region and program `len` bytes of `data` at its start.
+//
+// Both backends guarantee the other core is not executing from flash for the
+// duration: the Pico build parks core1 via flash_safe_execute (without which
+// the audio core races the erase and buzzes), and the ESP32-S31 build relies on
+// esp_partition_* taking the flash-op lock.
+bool config_storage_write(const void *data, size_t len);
+
+} // namespace port

--- a/src/port/port_gpio.h
+++ b/src/port/port_gpio.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+
+// The user-configurable status GPIO (see src/status_gpio.cpp), which drives an
+// external LED or acts as a momentary button output. Pin numbering is the
+// platform's own -- config stores a raw pin number, so a config written on a
+// Pico does not carry over to an ESP32-S31 board.
+
+namespace port {
+
+// Number of GPIO pins the platform exposes; status_gpio validates against this.
+extern const uint32_t kNumGpioPins;
+
+// Configure `pin` as a push-pull output, driven low.
+void gpio_init_output(uint32_t pin);
+
+void gpio_write(uint32_t pin, bool level);
+
+} // namespace port

--- a/src/port/port_led.h
+++ b/src/port/port_led.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace port {
+
+// Single status LED, driven as on/off.
+//
+// On Pico2W this is the CYW43 wireless-chip GPIO. On the
+// ESP32-S31-Function-CoreBoard-1 there is no plain status LED — the board has
+// one addressable RGB LED on GPIO60 — so the backend drives it over RMT and
+// maps "on" to a fixed dim white. Anything wanting colour should extend this
+// interface rather than reaching for the strip driver directly.
+
+void led_init();
+void led_set(bool on);
+
+} // namespace port

--- a/src/port/port_mem.h
+++ b/src/port/port_mem.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "port_platform.h"
+
+// Placement attributes for hot code and data.
+//
+// On RP2350 these map to the pico-sdk's XIP-avoiding sections; on ESP32-S31
+// they map to IRAM/DRAM. Both platforms are keeping the same promise: this
+// symbol must not be fetched over a flash-cache miss on the audio/BT hot path.
+
+#if defined(PORT_PLATFORM_PICO)
+
+#include "pico.h"
+
+#define PORT_FAST_FUNC(fn) __not_in_flash_func(fn)
+#define PORT_FAST_DATA __not_in_flash("port_fast")
+
+#elif defined(PORT_PLATFORM_ESP32S31)
+
+#include "esp_attr.h"
+
+#define PORT_FAST_FUNC(fn) IRAM_ATTR fn
+#define PORT_FAST_DATA DRAM_ATTR
+
+#endif

--- a/src/port/port_platform.h
+++ b/src/port/port_platform.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Platform selection. Kept free of C++ so C translation units (ram_mem.c) can
+// pull in port_mem.h for the placement macros without dragging in the rest.
+//
+// Exactly one PORT_PLATFORM_* macro is defined, driven by what the build system
+// already tells us.
+
+#if defined(PICO_ON_DEVICE) || defined(PICO_SDK_VERSION_MAJOR)
+#define PORT_PLATFORM_PICO 1
+#elif defined(ESP_PLATFORM)
+#define PORT_PLATFORM_ESP32S31 1
+#else
+#error "port: unknown platform; expected pico-sdk or ESP-IDF"
+#endif

--- a/src/port/port_queue.h
+++ b/src/port/port_queue.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstddef>
+
+// Fixed-capacity, fixed-element-size SPSC/MPMC queue used to hand audio and
+// report buffers between the two cores.
+//
+// Contract (matches pico_util queue_t, which the existing call sites assume):
+//   - try_add/try_remove never block and never allocate;
+//   - both are safe to call from ISR context as well as task context;
+//   - elements are copied by value, element_size bytes at a time.
+//
+// port_queue.h is on the audio hot path. cmake/relocate_to_ram.cmake already
+// pulls pico_util's queue add/remove into RAM; the wrappers here are inline so
+// that relocation still applies.
+
+#if defined(PORT_PLATFORM_PICO)
+#include "pico/port_queue_impl.h"
+#elif defined(PORT_PLATFORM_ESP32S31)
+#include "esp32s31/port_queue_impl.h"
+#endif

--- a/src/port/port_sync.h
+++ b/src/port/port_sync.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// Cross-core mutual exclusion.
+//
+// port::CriticalSection is an SMP-safe spinlock that also masks interrupts on
+// the calling core — matching pico-sdk critical_section_t semantics, which the
+// audio and BT paths rely on to guard state shared with the second core.
+//
+// It is NOT recursive on either platform: taking the same section twice on one
+// core deadlocks.
+//
+// port::irq_save()/irq_restore() mask interrupts on the calling core only, with
+// no cross-core exclusion. Use a CriticalSection unless you specifically need
+// the bare mask (flash writes do).
+
+#if defined(PORT_PLATFORM_PICO)
+#include "pico/port_sync_impl.h"
+#elif defined(PORT_PLATFORM_ESP32S31)
+#include "esp32s31/port_sync_impl.h"
+#endif
+
+namespace port {
+
+// RAII guard; prefer this over manual enter/exit at new call sites.
+class CriticalGuard {
+public:
+    explicit CriticalGuard(CriticalSection &cs) : cs_(cs) { cs_.enter(); }
+    ~CriticalGuard() { cs_.exit(); }
+    CriticalGuard(const CriticalGuard &) = delete;
+    CriticalGuard &operator=(const CriticalGuard &) = delete;
+
+private:
+    CriticalSection &cs_;
+};
+
+} // namespace port

--- a/src/port/port_sys.h
+++ b/src/port/port_sys.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+
+namespace port {
+
+// Bring the CPU to the firmware's target operating point. On RP2350 this sets
+// the core voltage and system clock; on ESP32-S31 clock setup is handled by the
+// bootloader and sdkconfig, so this only asserts the result.
+void clocks_init();
+
+// True while the board's user button is held.
+//
+// RP2350 has no dedicated user button: BOOTSEL is read by briefly floating the
+// QSPI CSn line, which requires parking the other core (flash_safe_execute).
+// That makes this call comparatively expensive, so keep it on the existing
+// ~10 Hz poll cadence rather than sampling it freely. The
+// ESP32-S31-Function-CoreBoard-1 has a real BOOT button and reads it cheaply.
+bool boot_button_pressed();
+
+// Register the calling core as a flash-safe victim, so a flash erase/program on
+// the other core can park it. Called once from the audio worker at startup.
+void worker_flash_safe_init();
+
+// Force the board's switching regulator into PWM mode where the board has one
+// under software control. Pico W / Pico 2 W expose an SMPS mode pin through the
+// CYW43; left in PFM/burst mode the regulator whines audibly under this
+// firmware's load (upstream #207). No-op on targets without such a pin.
+void smps_force_pwm();
+
+bool watchdog_caused_reboot();
+void watchdog_enable(uint32_t timeout_ms);
+void watchdog_update();
+
+// Warm reset that re-runs the application from flash. Deliberately NOT a
+// watchdog reset: on RP2350 a watchdog reset drops into the bootrom's BOOTSEL
+// mode instead of restarting the app.
+[[noreturn]] void reboot();
+
+// Whether reboot_to_bootloader() can actually reach a flash mode on this
+// target. True on RP2350, where the bootrom is one call away and BOOTSEL
+// otherwise has to be held *during* power-up -- so the gesture genuinely saves
+// an unplug/replug. False on ESP32-S31: download boot exists in silicon (there
+// is even an EFUSE_DIS_FORCE_DOWNLOAD to switch it off) but is entered by
+// strapping GPIO61 low at reset, and the register that forces it from software
+// is not exposed for this target anywhere in ESP-IDF -- S2/S3 use
+// RTC_CNTL_OPTION1_REG.FORCE_DOWNLOAD_BOOT, and the S31 has no rtc_cntl_reg.h
+// at all. Guessing an address on preview silicon is how boards get wedged, so
+// callers should offer their own fallback rather than call this blindly.
+bool has_bootloader_reboot();
+
+// Enter the ROM bootloader so the host sees a firmware-update device.
+// Does not return. Only meaningful when has_bootloader_reboot() is true.
+[[noreturn]] void reboot_to_bootloader();
+
+// Bluetooth controller transport. On RP2350 this is the CYW43 driver over
+// PIO-SPI and must be pumped from the main loop; on ESP32-S31 the controller is
+// on-die and poll() is a no-op.
+bool bt_transport_init();
+void bt_transport_poll();
+
+} // namespace port

--- a/src/port/port_thread.h
+++ b/src/port/port_thread.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace port {
+
+// Run `entry` on the second core, using the caller-provided static stack.
+//
+// Both backends pin the work to core 1 and use the supplied buffer as its
+// stack, so the audio core's memory stays statically allocated and its
+// high-water mark remains measurable (see debug_fill_core1_stack_watermark).
+// `entry` is not expected to return.
+void launch_worker(void (*entry)(), uint32_t *stack, size_t stack_bytes);
+
+} // namespace port

--- a/src/port/port_time.h
+++ b/src/port/port_time.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+
+// Monotonic time since boot. The firmware only ever uses timestamps as plain
+// integers (deadline comparisons and elapsed-time maths), so the port API
+// exposes integers rather than an opaque time type.
+
+namespace port {
+
+// Microseconds since boot, full width.
+uint64_t now_us();
+
+// Microseconds since boot, truncated. Callers use this only for short
+// intervals where 32-bit wraparound (~71 minutes) is already handled.
+uint32_t now_us32();
+
+// Milliseconds since boot. Replaces to_ms_since_boot(get_absolute_time()).
+uint32_t now_ms();
+
+void delay_ms(uint32_t ms);
+void delay_us(uint32_t us);
+
+// Hint for a spin-wait body; may compile to nothing.
+void spin_hint();
+
+} // namespace port
+
+#if defined(PORT_PLATFORM_PICO)
+#include "pico/port_time_impl.h"
+#elif defined(PORT_PLATFORM_ESP32S31)
+#include "esp32s31/port_time_impl.h"
+#endif

--- a/src/port/port_timer.h
+++ b/src/port/port_timer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+
+namespace port {
+
+// One-shot deferred callback.
+//
+// The callback runs off a timer context on both platforms (pico-sdk alarm pool
+// / esp_timer), so it must be short and must not block. kNoTimer is the "not
+// scheduled" value, chosen as 0 to match how the existing call sites test it.
+
+using TimerId = int32_t;
+constexpr TimerId kNoTimer = 0;
+
+// Schedule `cb(ctx)` to run once after `delay_ms`. Returns kNoTimer on failure.
+TimerId timer_once_ms(uint32_t delay_ms, void (*cb)(void *ctx), void *ctx);
+
+// Cancel a pending timer. Safe to call with kNoTimer, and safe to call after
+// the callback has already run.
+void timer_cancel(TimerId id);
+
+} // namespace port

--- a/src/port/port_usb.h
+++ b/src/port/port_usb.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+
+// The bits of USB bring-up that are board-provided rather than TinyUSB-generic.
+//
+// On Pico these come from TinyUSB's example BSP (bsp/board_api.h), which ships
+// inside the pico-sdk. ESP-IDF has no equivalent BSP, so the ESP32-S31 backend
+// supplies them directly.
+
+namespace port {
+
+// Root-hub port the device stack runs on.
+extern const uint8_t kUsbRhPort;
+
+// Bus speed to request in tusb_rhport_init_t.
+//
+// RP2350 is full-speed only. ESP32-S31 has a high-speed OTG with a UTMI PHY and
+// no FS/LS PHY at all (soc_caps: SOC_USB_UTMI_PHY_NUM 1, SOC_USB_FSLS_PHY_NUM 0),
+// so the descriptors' isochronous sizing assumptions need revisiting there --
+// see ports/esp32s31/README.md.
+extern const uint8_t kUsbSpeed;
+
+// Board init before tusb_init(), and the follow-up some BSPs need afterwards.
+void board_init();
+void board_init_after_tusb();
+
+// Fill `desc_str` with up to `max_chars` UTF-16 characters of a unique serial
+// number; returns the number of characters written.
+size_t usb_get_serial(uint16_t *desc_str, size_t max_chars);
+
+} // namespace port

--- a/src/ps_shortcut.cpp
+++ b/src/ps_shortcut.cpp
@@ -1,8 +1,8 @@
 ﻿#include "ps_shortcut.h"
+#include "port/port.h"
 #include "config.h"
 #include "tusb.h"
 #include "class/hid/hid.h"
-#include "pico/time.h"
 
 #define PS_KBD_INSTANCE 1
 
@@ -31,7 +31,7 @@ void ps_shortcut_tick(const uint8_t *data, uint16_t len) {
     if (len < 10) return;
     if (!get_config().ps_shortcut_enabled) return;
 
-    uint32_t now = to_ms_since_boot(get_absolute_time());
+    uint32_t now = port::now_ms();
     bool raw_ps = (data[9] & 0x01) != 0;
 
     if (raw_ps) {

--- a/src/ram_mem.c
+++ b/src/ram_mem.c
@@ -17,9 +17,9 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "pico.h"
+#include "port/port_mem.h"
 
-void *__not_in_flash_func(memcpy)(void *restrict dst, const void *restrict src, size_t n) {
+void *PORT_FAST_FUNC(memcpy)(void *restrict dst, const void *restrict src, size_t n) {
     uint8_t *d = (uint8_t *) dst;
     const uint8_t *s = (const uint8_t *) src;
     if ((((uintptr_t) d | (uintptr_t) s) & 3u) == 0u) {
@@ -34,7 +34,7 @@ void *__not_in_flash_func(memcpy)(void *restrict dst, const void *restrict src, 
     return dst;
 }
 
-void *__not_in_flash_func(memset)(void *dst, int c, size_t n) {
+void *PORT_FAST_FUNC(memset)(void *dst, int c, size_t n) {
     uint8_t *d = (uint8_t *) dst;
     const uint8_t b = (uint8_t) c;
     if (((uintptr_t) d & 3u) == 0u) {
@@ -48,7 +48,7 @@ void *__not_in_flash_func(memset)(void *dst, int c, size_t n) {
     return dst;
 }
 
-void *__not_in_flash_func(memmove)(void *dst, const void *src, size_t n) {
+void *PORT_FAST_FUNC(memmove)(void *dst, const void *src, size_t n) {
     uint8_t *d = (uint8_t *) dst;
     const uint8_t *s = (const uint8_t *) src;
     if (d == s || n == 0u) return dst;

--- a/src/status_gpio.cpp
+++ b/src/status_gpio.cpp
@@ -1,16 +1,15 @@
+#include "port/port.h"
 #include "status_gpio.h"
 
 #include "config.h"
-#include "hardware/gpio.h"
-#include "pico/time.h"
 
 #define BUTTON_PRESS_MS 200
 
-static volatile alarm_id_t button_alarm_id;
+static volatile port::TimerId button_alarm_id = port::kNoTimer;
 
 bool status_gpio_pin_valid(const uint8_t pin) {
     if (pin == STATUS_GPIO_DISABLED) return true;
-    if (pin >= NUM_BANK0_GPIOS) return false;
+    if (pin >= port::kNumGpioPins) return false;
 
 #ifdef PICO_DEFAULT_UART_TX_PIN
     if (pin == PICO_DEFAULT_UART_TX_PIN) return false;
@@ -55,32 +54,29 @@ void gpio_on_connect() {
     const auto &config = get_config();
     if (config.status_gpio_pin == STATUS_GPIO_DISABLED) return;
 
-    gpio_put(config.status_gpio_pin, true);
+    port::gpio_write(config.status_gpio_pin, true);
 
     if (config.status_gpio_mode == STATUS_GPIO_MODE_BUTTON) {
-        button_alarm_id = add_alarm_in_ms(BUTTON_PRESS_MS, [](alarm_id_t, void *user_data) -> int64_t {
-            gpio_put((uint) (uintptr_t) user_data, false);
-            button_alarm_id = 0;
-            return 0;
-        }, (void *) (uintptr_t) config.status_gpio_pin, false);
+        button_alarm_id = port::timer_once_ms(BUTTON_PRESS_MS, [](void *user_data) {
+            port::gpio_write((uint32_t) (uintptr_t) user_data, false);
+            button_alarm_id = port::kNoTimer;
+        }, (void *) (uintptr_t) config.status_gpio_pin);
 
-        if (button_alarm_id <= 0) {
-            button_alarm_id = 0;
-            gpio_put(config.status_gpio_pin, false);
+        if (button_alarm_id == port::kNoTimer) {
+            port::gpio_write(config.status_gpio_pin, false);
         }
     }
 }
 
 void gpio_on_disconnect() {
-    if (button_alarm_id > 0) {
-        cancel_alarm(button_alarm_id);
-        button_alarm_id = 0;
+    if (button_alarm_id != port::kNoTimer) {
+        port::timer_cancel(button_alarm_id);
+        button_alarm_id = port::kNoTimer;
     }
 
     const auto &config = get_config();
     if (config.status_gpio_pin == STATUS_GPIO_DISABLED) return;
 
-    gpio_init(config.status_gpio_pin);
-    gpio_put(config.status_gpio_pin, false);
-    gpio_set_dir(config.status_gpio_pin, GPIO_OUT);
+    port::gpio_init_output(config.status_gpio_pin);
+    port::gpio_write(config.status_gpio_pin, false);
 }

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -130,6 +130,10 @@
 
 // UAC1 Full-Speed endpoint size
 #define CFG_TUD_AUDIO_FUNC_1_SAMPLE_RATE            48000
+// _is_highspeed stays false even on the high-speed target: the isochronous
+// endpoints keep a 1 ms service interval there (bInterval 4 = 8 microframes),
+// so the bytes carried per service interval are the full-speed figure. Passing
+// true would size them per 125 us microframe and starve the audio path.
 #define CFG_TUD_AUDIO_FUNC_1_FORMAT_1_EP_SZ_OUT     TUD_AUDIO_EP_SIZE(false, CFG_TUD_AUDIO_FUNC_1_SAMPLE_RATE, CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_RX, CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX)
 #define CFG_TUD_AUDIO_FUNC_1_FORMAT_1_EP_SZ_IN      TUD_AUDIO_EP_SIZE(false, CFG_TUD_AUDIO_FUNC_1_SAMPLE_RATE, CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX, CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX)
 #define CFG_TUD_AUDIO_FUNC_1_EP_OUT_SZ_MAX          CFG_TUD_AUDIO_FUNC_1_FORMAT_1_EP_SZ_OUT

--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -6,7 +6,6 @@
 
 #include "bt.h"
 #include "tusb.h"
-#include "bsp/board_api.h"
 #include "config.h"
 #include "utils.h"
 

--- a/src/usb_descriptors.cpp
+++ b/src/usb_descriptors.cpp
@@ -23,7 +23,7 @@
  *
  */
 
-#include "bsp/board_api.h"
+#include "port/port.h"
 #include "tusb.h"
 #include "config.h"
 
@@ -136,6 +136,25 @@ uint8_t const *tud_descriptor_device_cb(void) {
 //--------------------------------------------------------------------+
 // Configuration Descriptor
 //--------------------------------------------------------------------+
+
+// Endpoint service interval, in milliseconds, expressed the way the descriptor
+// wants it for the speed we actually enumerate at.
+//
+// bInterval means different things per speed: full speed counts 1 ms frames
+// directly, high speed is an exponent (2^(bInterval-1) microframes of 125 us).
+// A literal 1 in a high-speed descriptor asks for 8x the intended rate. Periods
+// that are not a power of two round down, polling slightly more often.
+static constexpr uint8_t ep_interval(const unsigned period_ms) {
+#if TUD_OPT_HIGH_SPEED
+    const unsigned microframes = period_ms * 8u;
+    uint8_t b = 1;
+    while ((1u << b) <= microframes) ++b;
+    return b;
+#else
+    return static_cast<uint8_t>(period_ms);
+#endif
+}
+
 uint8_t descriptor_configuration[] = {
     // --- CONFIGURATION DESCRIPTOR ---
     0x09, // bLength
@@ -296,7 +315,7 @@ uint8_t descriptor_configuration[] = {
     0x01, // bEndpointAddress: OUT EP1
     0x09, // bmAttributes: Isochronous, Adaptive
     0x88, 0x01, // wMaxPacketSize: 392 bytes
-    0x01, // bInterval: 1
+    ep_interval(1), // bInterval: 1 ms service interval
     0x00, // bRefresh
     0x00, // bSynchAddress
 
@@ -355,7 +374,7 @@ uint8_t descriptor_configuration[] = {
     0x82, // bEndpointAddress: IN EP2
     0x05, // bmAttributes: Isochronous, Asynchronous
     0xC4, 0x00, // wMaxPacketSize: 196 bytes ((48+1) samples * 2 ch * 2 bytes)
-    0x01, // bInterval: 1
+    ep_interval(1), // bInterval: 1 ms service interval
     0x00, // bRefresh
     0x00, // bSynchAddress
 
@@ -394,7 +413,7 @@ uint8_t descriptor_configuration[] = {
     0x84, // bEndpointAddress: IN EP4
     0x03, // bmAttributes: Interrupt
     0x40, 0x00, // wMaxPacketSize: 64
-    0x01, // bInterval: 1 (polling every 4ms -> 1ms)
+    ep_interval(1), // bInterval: overwritten per polling_rate_mode below
 
     // Endpoint Descriptor (HID OUT: EP3)
     0x07, // bLength
@@ -402,7 +421,7 @@ uint8_t descriptor_configuration[] = {
     0x03, // bEndpointAddress: OUT EP3
     0x03, // bmAttributes: Interrupt
     0x40, 0x00, // wMaxPacketSize: 64
-    0x01, // bInterval: 1 (polling every 4ms -> 1ms)
+    ep_interval(1), // bInterval: overwritten per polling_rate_mode below
 
 #if ENABLE_SERIAL
     // --- CDC ACM (USB Serial) ---
@@ -437,25 +456,55 @@ uint8_t descriptor_configuration[] = {
     0x87, // bEndpointAddress: IN EP7
     0x03, // bmAttributes: Interrupt
     0x08, 0x00, // wMaxPacketSize: 8 (boot keyboard report)
-    0x0A, // bInterval: 10ms
+    ep_interval(10), // bInterval: 10 ms (8 ms at high speed)
 #endif
 };
+
+#if TUD_OPT_HIGH_SPEED
+// Invoked when received GET DEVICE QUALIFIER DESCRIPTOR
+//
+// Only high-speed-capable devices answer this. TinyUSB's weak stub returns NULL
+// and stalls, which hosts tolerate but is a standards violation at high speed.
+// Fields mirror desc_device so the two cannot drift.
+uint8_t const *tud_descriptor_device_qualifier_cb(void) {
+    static tusb_desc_device_qualifier_t desc_qualifier = {
+        .bLength = sizeof(tusb_desc_device_qualifier_t),
+        .bDescriptorType = TUSB_DESC_DEVICE_QUALIFIER,
+        .bcdUSB = 0x0200,
+        .bDeviceClass = 0x00,
+        .bDeviceSubClass = 0x00,
+        .bDeviceProtocol = 0x00,
+        .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+        .bNumConfigurations = 0x01,
+        .bReserved = 0x00,
+    };
+    desc_qualifier.bcdUSB = desc_device.bcdUSB;
+    desc_qualifier.bDeviceClass = desc_device.bDeviceClass;
+    desc_qualifier.bDeviceSubClass = desc_device.bDeviceSubClass;
+    desc_qualifier.bDeviceProtocol = desc_device.bDeviceProtocol;
+    desc_qualifier.bMaxPacketSize0 = desc_device.bMaxPacketSize0;
+    desc_qualifier.bNumConfigurations = desc_device.bNumConfigurations;
+    return reinterpret_cast<uint8_t const *>(&desc_qualifier);
+}
+#endif
 
 // Invoked when received GET CONFIGURATION DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
 uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
     (void) index; // for multiple configurations
-    auto bInterval = 0x01;
+    // Same speed-dependent encoding as the static descriptors above; these are
+    // periods in milliseconds, not raw bInterval values.
+    auto bInterval = ep_interval(1);
     switch (get_config().polling_rate_mode) {
         case 0:
-            bInterval = 0x04;
+            bInterval = ep_interval(4);
             break;
         case 1:
-            bInterval = 0x02;
+            bInterval = ep_interval(2);
             break;
         case 2:
-            bInterval = 0x01;
+            bInterval = ep_interval(1);
             break;
     }
     constexpr auto offset = CONFIG_DESC_LEN_BASE;
@@ -952,7 +1001,7 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
             break;
 
         case STRID_SERIAL:
-            chr_count = board_usb_get_serial(_desc_str + 1, 32) + 1;
+            chr_count = port::usb_get_serial(_desc_str + 1, 32) + 1;
             _desc_str[chr_count] = '2'; // refresh windows cache (bumped for 2-ch mic)
             break;
 
@@ -986,19 +1035,11 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
 //--------------------------------------------------------------------+
 // Microsoft OS 2.0 descriptors (carried via BOS).
 //
-// Why this is here: the dongle is a composite device with USB Audio Class
-// interfaces. By default Windows audio engine policy keeps USB audio devices
-// at D0 even during system S3, blocking selective-suspend for the whole
-// composite. Without selective-suspend the device never enters USB suspend,
-// so tud_remote_wakeup() never works -- breaking wake-on-PS.
-//
-// MS OS 2.0 lets us tell Windows "yes, please selective-suspend this audio
-// function": we set the registry property "SelectiveSuspendEnabled" = 1 on
-// the audio function (interface 0). This causes Windows to write
-//   HKLM\SYSTEM\CurrentControlSet\Enum\USB\<VID&PID>\<instance>
-//        \Device Parameters\SelectiveSuspendEnabled = 1
-// at enumeration time, opting our audio function in to selective suspend
-// without breaking haptics.
+// Windows audio policy keeps USB audio devices at D0 even during S3, which
+// blocks selective-suspend for the whole composite -- so the device never enters
+// USB suspend and tud_remote_wakeup() never fires, breaking wake-on-PS. Setting
+// the "SelectiveSuspendEnabled" registry property on the audio function opts it
+// back in without breaking haptics.
 //
 // Reference: "Microsoft OS 2.0 Descriptors Specification".
 //--------------------------------------------------------------------+

--- a/src/utils.h
+++ b/src/utils.h
@@ -10,7 +10,7 @@
 #include <iostream>
 
 #include "hci_cmd.h"
-#include "pico/platform/sections.h"
+#include "port/port_mem.h"
 
 inline const char *opcode_to_str(const uint16_t opcode) {
     switch (opcode) {
@@ -110,7 +110,7 @@ inline constexpr auto make_crc32_table() {
     return table;
 }
 
-inline constexpr std::array<uint32_t, 256> __not_in_flash("crc32_lookup_table")
+inline constexpr std::array<uint32_t, 256> PORT_FAST_DATA
 crc32_lookup_table = make_crc32_table();
 
 inline uint32_t crc32_seeded(const uint8_t *data, size_t size, const uint32_t seed) {

--- a/src/wake.cpp
+++ b/src/wake.cpp
@@ -2,6 +2,7 @@
 // Created by awalol on 2026/4/30.
 //
 
+#include "port/port.h"
 #include "wake.h"
 
 #ifdef ENABLE_WAKE_HID
@@ -11,8 +12,6 @@
 #include "bt.h"
 #include "tusb.h"
 #include "device/dcd.h"
-#include "pico/sync.h"
-#include "pico/time.h"
 #include "ps_shortcut.h"
 #include "config.h"
 
@@ -61,7 +60,7 @@ typedef enum {
     WAKE_DONE,
 } wake_state_t;
 
-static critical_section_t wake_cs;
+static port::CriticalSection wake_cs;
 static volatile bool host_suspended = false;
 static volatile bool host_resumed_event = false;
 static wake_state_t state = WAKE_IDLE;
@@ -79,7 +78,7 @@ static volatile uint64_t reconnect_until_us = 0;
 
 static void enter_state(wake_state_t s) {
     state = s;
-    state_entered_us = time_us_64();
+    state_entered_us = port::now_us();
 }
 
 static void request_host_wake(const char *reason) {
@@ -95,16 +94,16 @@ static void request_host_wake(const char *reason) {
     }
 
     if (ok) {
-        critical_section_enter_blocking(&wake_cs);
+        wake_cs.enter();
         state = WAKE_REQUESTED;
-        state_entered_us = time_us_64();
-        critical_section_exit(&wake_cs);
+        state_entered_us = port::now_us();
+        wake_cs.exit();
         WAKE_DBG("%s -> REQUESTED", reason);
     }
 #ifdef WAKE_DEBUG
     else {
         static uint64_t last_log = 0;
-        const uint64_t now = time_us_64();
+        const uint64_t now = port::now_us();
         if (now - last_log > 5000000) {
             WAKE_DBG("%s, tud_remote_wakeup()=0 (USB bus not in suspend) -- 5s heartbeat", reason);
             last_log = now;
@@ -114,13 +113,13 @@ static void request_host_wake(const char *reason) {
 }
 
 void wake_init(void) {
-    critical_section_init(&wake_cs);
+    wake_cs.init();
 }
 
 // Called right before a deliberate USB reconnect (FUNC_RECONNECT): arm a grace window so the
 // suspend the reconnect causes is ignored, and drop any already-pending disconnect.
 void wake_note_usb_reconnect(void) {
-    reconnect_until_us = time_us_64() + WAKE_RECONNECT_GRACE_US;
+    reconnect_until_us = port::now_us() + WAKE_RECONNECT_GRACE_US;
     suspend_at_us = 0;
 }
 
@@ -130,7 +129,7 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
     // A deliberate Reconnect USB (FUNC_RECONNECT) tears the bus down and back up, which looks
     // like a suspend but is not a host sleep -- ignore it so it cannot disconnect the controller.
     // See wake_note_usb_reconnect().
-    if (time_us_64() < reconnect_until_us) {
+    if (port::now_us() < reconnect_until_us) {
         WAKE_DBG("suspend during reconnect grace -> ignored");
         return;
     }
@@ -138,7 +137,7 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
     // off when its Bluetooth link is disconnected, saving battery during a real sleep/shutdown.
     // A spurious hub suspend is filtered by the debounce below, not a gate -- it resumes and
     // tud_resume_cb / tud_mount_cb cancel the pending disconnect first.
-    suspend_at_us = time_us_64();
+    suspend_at_us = port::now_us();
     host_suspended = true;
     host_resumed_event = false;
     
@@ -149,7 +148,7 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
     // (e.g. Linux ignored a keystroke and left the endpoint busy forever),
     // we must abort and reset so the NEXT wake attempt can trigger.
     state = WAKE_PENDING_PRESS;
-    state_entered_us = time_us_64();
+    state_entered_us = port::now_us();
     prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
     key_attempts = 0;
     WAKE_DBG("-> PENDING_PRESS");
@@ -157,10 +156,10 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en) {
 
 void wake_on_bt_connect(void) {
     if (!get_config().enable_wake) return;
-    critical_section_enter_blocking(&wake_cs);
+    wake_cs.enter();
     const bool should_wake = host_suspended &&
         (state == WAKE_IDLE || state == WAKE_DONE || state == WAKE_PENDING_PRESS);
-    critical_section_exit(&wake_cs);
+    wake_cs.exit();
 
     if (should_wake) {
         request_host_wake("BT reconnect while suspended");
@@ -209,11 +208,11 @@ void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
     const uint8_t b8 = hid_input[8];
     const uint8_t b9 = hid_input[9];
 
-    critical_section_enter_blocking(&wake_cs);
+    wake_cs.enter();
     const bool changed = (b7 != prev_b7) || (b8 != prev_b8) || (b9 != prev_b9);
     const bool armable = (state == WAKE_IDLE || state == WAKE_DONE || state == WAKE_PENDING_PRESS);
     prev_b7 = b7; prev_b8 = b8; prev_b9 = b9;
-    critical_section_exit(&wake_cs);
+    wake_cs.exit();
 
     if (changed && armable) {
         request_host_wake("button event");
@@ -221,15 +220,15 @@ void wake_on_bt_input(const uint8_t *hid_input, uint16_t len) {
 }
 
 void wake_on_bt_disconnect(void) {
-    critical_section_enter_blocking(&wake_cs);
+    wake_cs.enter();
     state = WAKE_IDLE;
     prev_b7 = 0x08; prev_b8 = 0x00; prev_b9 = 0x00;
-    critical_section_exit(&wake_cs);
+    wake_cs.exit();
     ps_shortcut_reset();
 }
 
 void wake_task(void) {
-    const uint64_t now = time_us_64();
+    const uint64_t now = port::now_us();
 
     // Commit the deferred controller disconnect once we have stayed suspended past the debounce
     // window (a genuine host sleep/shutdown). Runs regardless of enable_wake -- it is a
@@ -245,10 +244,10 @@ void wake_task(void) {
     // The wake-UP FSM below only runs when wake is enabled.
     if (!get_config().enable_wake) return;
 
-    critical_section_enter_blocking(&wake_cs);
+    wake_cs.enter();
     const wake_state_t s = state;
     const uint64_t entered = state_entered_us;
-    critical_section_exit(&wake_cs);
+    wake_cs.exit();
 
     switch (s) {
         case WAKE_IDLE:
@@ -274,15 +273,15 @@ void wake_task(void) {
                 const bool sent = tud_hid_n_report(WAKE_KBD_INSTANCE, 0, rpt, sizeof(rpt));
                 WAKE_DBG("REQUESTED: sent keydown 0x%02X -> %d", WAKE_KEYCODE_F15, (int)sent);
                 if (sent) {
-                    critical_section_enter_blocking(&wake_cs);
+                    wake_cs.enter();
                     enter_state(WAKE_KEY_DOWN);
-                    critical_section_exit(&wake_cs);
+                    wake_cs.exit();
                 }
             } else if (now - entered > WAKE_REQUEST_TIMEOUT_US) {
                 WAKE_DBG("REQUESTED timeout 5s -> DONE (no resume signaling; may have already woken)");
-                critical_section_enter_blocking(&wake_cs);
+                wake_cs.enter();
                 enter_state(WAKE_DONE);
-                critical_section_exit(&wake_cs);
+                wake_cs.exit();
             }
             return;
         }
@@ -303,9 +302,9 @@ void wake_task(void) {
             const bool sent = tud_hid_n_report(WAKE_KBD_INSTANCE, 0, up, sizeof(up));
             WAKE_DBG("KEY_DOWN: sent keyup -> %d", (int)sent);
             if (sent) {
-                critical_section_enter_blocking(&wake_cs);
+                wake_cs.enter();
                 enter_state(WAKE_KEY_UP_SENT);
-                critical_section_exit(&wake_cs);
+                wake_cs.exit();
             }
             return;
         }
@@ -334,16 +333,16 @@ void wake_task(void) {
                 WAKE_DBG("KEY_UP_SENT: retrying F15 (attempt %d/%d) -> %d",
                          (int)key_attempts + 1, (int)WAKE_KEY_ATTEMPTS, (int)sent);
                 if (sent) {
-                    critical_section_enter_blocking(&wake_cs);
+                    wake_cs.enter();
                     enter_state(WAKE_KEY_DOWN);
-                    critical_section_exit(&wake_cs);
+                    wake_cs.exit();
                 }
             } else {
                 WAKE_DBG("KEY_UP_SENT settle done -> DONE");
-                critical_section_enter_blocking(&wake_cs);
+                wake_cs.enter();
                 enter_state(WAKE_DONE);
                 key_attempts = 0;
-                critical_section_exit(&wake_cs);
+                wake_cs.exit();
             }
             return;
         }


### PR DESCRIPTION
> **Draft — not proposed for merge yet.**
>
> This is pre-release bring-up against preview silicon. The ESP32-S31-Function-CoreBoard-1 is a development
> board, not a dongle: it sources VBUS on the Type-A port through a TPS2051C whose enable is strapped high with
> no GPIO on the net, so it cannot be gated in software and the host cable has to be VBUS-disconnected. That is
> fine on a bench and wrong for something you hand to a user.
>
> The sensible time to merge is when a board actually intended as a dongle ships. Until then this is worth
> having open as a record of what the port needs and what it found — most of which turned out to be latent
> problems in the existing firmware rather than ESP32 problems.

## What this is

An ESP32-S31 target for DS5Dongle, added through a platform abstraction layer rather than by forking the
firmware. `src/port/` defines the interface the firmware needs from a platform — time, timers, GPIO, LED,
flash, queues, sync, threads, USB, and the Bluetooth transport — with backends for RP2350 and ESP32-S31.

BTstack is the host over the on-die BR/EDR controller (`CONFIG_BT_CONTROLLER_ONLY`) through a VHCI transport.
It drives the pollable embedded run loop from the superloop, exactly where the Pico build called
`cyw43_arch_poll()`, so every BTstack callback stays on one task — which the shared firmware requires, since
`bt_write()` uses a single static `send_element` and the report counters are non-atomic.

Four commits, each reviewable on its own: the layer (additive), the migration (where RP2350 is at risk), the
target, and the docs.

## RP2350 is unchanged

Every behavioural change is guarded to ESP32-S31. That was verified rather than assumed: stripping all
ESP32-guarded regions and diffing what the RP2350 preprocessor actually sees against master leaves only
mechanical differences — `__not_in_flash_func` → `PORT_FAST_FUNC`, `queue_t` → `port::Queue`, `port::` renames.
The `ResetLights` pulse and the per-link sequence counter reset are ESP32-only, confirmed absent from the
RP2350 image by symbol check.

The Pico build is hardware-tested on this branch, not just compiled.

## Verified on hardware (ESP32-S31)

Pairing, reconnect after both a PS-hold power-cycle and a dongle replug, USB enumeration of the emulated
controller, speaker and microphone audio under sustained load, and the lightbar handover after a power-cycle.

## Latent defects this surfaced, deliberately left alone on RP2350

The S31 is less forgiving than the CYW43439 and turned several existing bugs into visible failures. Each is
guarded to the new target. **None are fixed on RP2350, on purpose** — that target works, has field use behind
it, and its current shape may encode workarounds earlier maintainers hit and did not write down.

- **Duplicate HCI commands.** BTstack already answers the link key request, user confirmation, encryption
  request and incoming connection from `hci_run()`. Sending our own put two replies on the wire per request.
  The CYW43439 tolerates it; the S31 controller asserted in `olm_lmp_ssp.c` and reset.
- **Page scan violates the interlaced-scan rule.** Upstream pairs `interval == window` with interlaced scan,
  which Core Spec 5.4 Vol 2 Part B §8.3.1 forbids, and which is also a 100% duty cycle. Neither HCI command
  validates the pair, so both return success and the controller is silently misconfigured.
- **`l2cap_send()` status is discarded.** `init_feature()` issues four requests back to back; where ACL buffers
  are scarce, three vanished silently. Fixing this by deferring the sends is a trap — it broke RP2350 USB
  enumeration once already, because the `0x20` reply is what drives the only caller of `tud_connect()`.

Also fixed on both targets, from a preemption audit: a timer use-after-free, blocking `printf` on two
must-not-block contexts, a two-consumer race on `audio_spk_fifo`, and a non-atomic `mic_active`.

## Two findings worth recording, because both cost hardware cycles

**Reconnect.** Reconnect after a PS-hold power-cycle took ~20s or failed. Two changes went in together — page
scan interval, and disabling inquiry scan — and reconnect started working, so both looked load-bearing.
Reverting inquiry scan alone showed it contributed nothing: the page scan interval was doing the work. Duty
cycle went *down* (100% → 22%) while reliability went *up*, which is the tell that the 100% scan was starving
the LMP exchange of the link it was supposed to be accepting.

**Lightbar.** After a power-cycle the DualSense stopped accepting host colours. The first conclusion — that
disabling inquiry scan caused it — was wrong, and wrong because the test was confounded: that build also had
diagnostic tracing enabled, whose blocking `printf`s sit on the output report path. With tracing off the
symptom returned. The real cause is documented DualSense behaviour: in wireless mode it holds its LEDs until
the host pulses `ResetLights`, and Steam never sends that bit (`reset=0` on every host report, verified on the
wire). A fresh pair releases them anyway; a power-cycle does not. Hence the pulse.

The lesson is in the port README: a test isolates only the variable you changed *deliberately*, and diagnostic
output is a variable.

## Notable implementation details

- **USB.** This target enumerates at **high speed**, matching the real DualSense. `ep_interval()` encodes
  `bInterval` for whichever speed is built -- it is an exponent at high speed, and getting that wrong is what
  broke an earlier attempt. The RP2350 is full-speed only and still presents full speed. One configure-time
  TinyUSB patch remains, unrelated to speed: `dcd_edpt_clear_stall()` sets `SD0PID_SEVNFRM` unconditionally,
  which on an isochronous endpoint is SetEvenFrame rather than a data toggle, and Windows sends
  CLEAR_FEATURE(ENDPOINT_HALT) on the iso OUT endpoint immediately before streaming.
- **RAM placement.** `main/ds5_hot_iram.lf` maps btstack's and TinyUSB's per-packet paths into internal RAM —
  the ESP-IDF counterpart of this repo's objcopy relocations for RP2350. 24.5 KB, leaving 55% of DIRAM free.
- **Link keys.** `hci_set_link_key_db()` must be called after `hci_init()` and is easy to miss: pico-sdk does
  it for the Pico in `btstack_cyw43.c`, and nothing on the ESP32 side corresponds to that file. Without it
  pairing succeeds and PS-only reconnect can never work.
- **A blob lead that was never closed out.** Early in bring-up, reconnect sometimes failed with LMP Response
  Timeout (`0x22`). Disassembling the closed BR/EDR blob showed `r_olc_pscan_recycle_sch` consulting
  `r_olc_acl_link_exists_by_bd_addr`, which would be consistent with a stale ACL record suppressing the page --
  but that is inference from control flow, not a confirmed root cause, and no host-side lever was found. It has
  not recurred since the page scan, link key and duplicate-command fixes landed, so it may already be resolved
  or merely masked. Recorded as a lead, not claimed as a defect.

## CI

A new `esp32s31` job builds the target and publishes `ds5-bridge-esp32s31-merged.bin`, a single image at
offset 0 so flashing needs no per-file offsets. ~4 minutes, in parallel with the existing matrix. It runs in
the `espressif/idf` master container rather than pinning a version, because the target is preview-only and has
no tagged release — a failure there means IDF master moved, not that this branch did.

## Not done

- `ports/esp32s31/README.md` carries the accepted risks and the tripwire that would make each unsafe. Worth
  reading before changing anything in the port.
