### PR TITLE
fix(audio): restore NoiseCancelEnable so the speaker is not attenuated

### DIFF
--- a/src/bt.cpp
+++ b/src/bt.cpp
@@ -744,6 +744,7 @@ static void __not_in_flash_func(l2cap_packet_handler)(uint8_t packet_type, uint1
                         .AllowAudioControl = 1,
                         .AllowLedColor = 1,
                         .MicSelect = get_config().mic_select,
+                        .NoiseCancelEnable = 1,
                         .AllowLightBrightnessChange = 1,
                         .AllowColorLightFadeAnimation = 1,
                         .LightFadeAnimation = LightFadeAnimation::FadeOut,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -216,6 +216,7 @@ void set_config(const uint8_t *new_config, const uint16_t len) {
     }
     state.AllowAudioControl = 1;
     state.MicSelect = config.body.mic_select;
+    state.NoiseCancelEnable = 1;
     update_state(state);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -260,6 +260,7 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
                 if (config.mic_select != 0) {
                     state.AllowAudioControl = 1;
                     state.MicSelect = config.mic_select;
+                    state.NoiseCancelEnable = 1;
                 }
                 if (config.lock_volume) {
                     state.AllowHeadphoneVolume = 0;


### PR DESCRIPTION
## Summary

The DualSense speaker has been roughly half as loud as it was on `v0.7.2-hotfix`. Bisected to ea93fad ("feat: mic/speaker select").

`AllowAudioControl` gates the **whole** AudioControl byte, not just `MicSelect`. ea93fad added it to the connect-time state to implement the mic-source selector:

```c
.AllowAudioControl = 1,
.MicSelect = get_config().mic_select,
```

`SetStateData` is zero-initialised and only `MicSelect` is populated, so this also commits `EchoCancelEnable`, `NoiseCancelEnable`, `OutputPathSelect` and `InputPathSelect` as `0` — fields the commit never intended to touch.

## Which bit

Isolated on hardware with single-bit builds against upstream master:

- byte 7 = `0x01` (`MicSelect` only) → **quiet**
- byte 7 = `0x08` (`NoiseCancelEnable` only) → **loud**

So `NoiseCancelEnable` is the field responsible. Why a noise-cancellation bit changes speaker output level is a question about the controller's codec — these bit names are community-derived and may not describe what the hardware actually does — but the behaviour reproduces consistently.

## The fix

Three lines, one at each site that already asserts `AllowAudioControl`:

```diff
+                        .NoiseCancelEnable = 1,     // bt.cpp, connect
+    state.NoiseCancelEnable = 1;                    // config.cpp, set_config
+                    state.NoiseCancelEnable = 1;    // main.cpp, forwarded host report
```

No structural change. The `mic_select != 0` guard in `main.cpp` is untouched and all mic-routing behaviour is exactly as before.

## Testing

Pico 2 W with a DualSense, CI-built artifacts: `v0.7.2-hotfix` loud, upstream master quiet, this branch loud.

Found by bisecting the 42 commits between `v0.7.2-hotfix` and master. Reverting ea93fad's *report-format* changes does not restore the volume — the regression is specifically the zeroed `NoiseCancelEnable`.
